### PR TITLE
Fix static web app output expressions in Bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1166,19 +1166,19 @@ output keyVaultName string = keyVault.outputs.name
 // ============================================================================
 
 @description('The name of the Static Web App (if deployed)')
-output staticWebAppName string = deployStaticWebApp ? (staticWebApp.outputs?.name ?? '') : ''
+output staticWebAppName string = deployStaticWebApp ? staticWebApp.outputs.name : ''
 
 @description('The URL of the Static Web App (if deployed)')
-output staticWebAppUrl string = deployStaticWebApp ? (staticWebApp.outputs?.url ?? '') : ''
+output staticWebAppUrl string = deployStaticWebApp ? staticWebApp.outputs.url : ''
 
 @description('The default hostname of the Static Web App (if deployed)')
-output staticWebAppHostname string = deployStaticWebApp ? (staticWebApp.outputs?.defaultHostname ?? '') : ''
+output staticWebAppHostname string = deployStaticWebApp ? staticWebApp.outputs.defaultHostname : ''
 
 @description('The principal ID of the Static Web App managed identity (if deployed)')
-output staticWebAppIdentityPrincipalId string = deployStaticWebApp ? (staticWebApp.outputs?.systemAssignedMIPrincipalId ?? '') : ''
+output staticWebAppIdentityPrincipalId string = deployStaticWebApp ? staticWebApp.outputs.systemAssignedMIPrincipalId : ''
 
 @description('The resource ID of the Static Web App (if deployed)')
-output staticWebAppResourceId string = deployStaticWebApp ? (staticWebApp.outputs?.resourceId ?? '') : ''
+output staticWebAppResourceId string = deployStaticWebApp ? staticWebApp.outputs.resourceId : ''
 
 // ============================================================================
 // Assign Key Vault Certificate User role to the managed identity


### PR DESCRIPTION
### Motivation
- Address Bicep compilation errors triggered by use of optional chaining (`?.`) and null-coalescing (`??`) in output expressions which produced BCP009/018/321 errors during parameter compilation.
- Prevent runtime/compile-time warnings about `module | null` access by simplifying the output expressions.

### Description
- Replace optional chaining and null-coalescing expressions in five static web app outputs with conditional expressions using `deployStaticWebApp ? ... : ''` in `infra/main.bicep`.
- Updated expressions include `staticWebApp.outputs.name`, `staticWebApp.outputs.url`, `staticWebApp.outputs.defaultHostname`, `staticWebApp.outputs.systemAssignedMIPrincipalId`, and `staticWebApp.outputs.resourceId`.
- This removes `?.` and `??` from the outputs to produce literal string fallback values when the static web app is not deployed.

### Testing
- No automated tests were executed as part of this change.
- The change was committed to the working branch and prepared as a PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966396dca488323b3594d2e2851d24b)