### PR TITLE
Add CORS configuration for Static Web App domains

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -523,6 +523,23 @@ module apiService 'br/public:avm/res/app/container-app:0.19.0' = {
             name: 'ASPNETCORE_DATAPROTECTION_KEYVAULT_KEYIDENTIFIER'
             value: 'https://${keyVault.outputs.name}${environment().suffixes.keyvaultDns}/Keys/dataprotection-key'
           }
+          // CORS configuration - allow requests from Static Web App
+          {
+            name: 'Cors__AllowedOrigins__0'
+            value: 'https://${computedCustomDomain}'
+          }
+          {
+            name: 'Cors__AllowedOrigins__1'
+            value: !empty(staticSiteCustomDomain) ? 'https://${staticSiteCustomDomain}' : ''
+          }
+          {
+            name: 'Cors__AllowedOrigins__2'
+            value: 'https://localhost:5001'
+          }
+          {
+            name: 'Cors__AllowedOrigins__3'
+            value: 'https://localhost:7001'
+          }
         ]
         probes: [
           {


### PR DESCRIPTION
## Problem

The Blazor WASM client at `https://dev.fencemark.com.au` was blocked by CORS policy when calling the API:

```
Access to fetch at 'https://ca-apiservice-xxx.azurecontainerapps.io/api/auth/me' 
from origin 'https://dev.fencemark.com.au' has been blocked by CORS policy
```

The API's CORS configuration only included localhost URLs, not the production Static Web App domains.

## Solution

Added CORS origins as environment variables in the API Container App configuration in `infra/main.bicep`:

| Variable | Value |
|----------|-------|
| `Cors__AllowedOrigins__0` | `https://${computedCustomDomain}` (e.g., dev.fencemark.com.au) |
| `Cors__AllowedOrigins__1` | `https://${staticSiteCustomDomain}` (from parameter) |
| `Cors__AllowedOrigins__2` | `https://localhost:5001` (local dev) |
| `Cors__AllowedOrigins__3` | `https://localhost:7001` (local dev) |

These environment variables override the `appsettings.json` CORS configuration at runtime.

## Testing

- [ ] Deploy infrastructure to dev environment
- [ ] Verify Blazor WASM client can call API without CORS errors
- [ ] Verify authentication flow works correctly

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>