### PR TITLE
Fix empty CORS origin when staticSiteCustomDomain is not set

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -528,10 +528,13 @@ module apiService 'br/public:avm/res/app/container-app:0.19.0' = {
             name: 'Cors__AllowedOrigins__0'
             value: 'https://${computedCustomDomain}'
           }
-          {
-            name: 'Cors__AllowedOrigins__1'
-            value: !empty(staticSiteCustomDomain) ? 'https://${staticSiteCustomDomain}' : ''
-          }
+          // Only include staticSiteCustomDomain if it's not empty
+          ...(!empty(staticSiteCustomDomain) ? [
+            {
+              name: 'Cors__AllowedOrigins__1'
+              value: 'https://${staticSiteCustomDomain}'
+            }
+          ] : [])
           {
             name: 'Cors__AllowedOrigins__2'
             value: 'https://localhost:5001'


### PR DESCRIPTION
## Problem

When `staticSiteCustomDomain` parameter is empty (its default), the CORS configuration still emits an environment variable with an empty string value:

```bicep
{
  name: 'Cors__AllowedOrigins__1'
  value: !empty(staticSiteCustomDomain) ? 'https://${staticSiteCustomDomain}' : ''  // Emits empty string
}
```

This could cause CORS issues as an empty origin would be added to the allowed origins array.

## Solution

Use Bicep's spread operator to conditionally include the environment variable only when `staticSiteCustomDomain` has a value:

```bicep
// Only include staticSiteCustomDomain if it's not empty
...(!empty(staticSiteCustomDomain) ? [
  {
    name: 'Cors__AllowedOrigins__1'
    value: 'https://${staticSiteCustomDomain}'
  }
] : [])
```

This ensures no empty CORS origin is ever emitted.

## Testing

- [ ] Deploy with `staticSiteCustomDomain` set - verify origin is included
- [ ] Deploy with `staticSiteCustomDomain` empty - verify no empty origin is emitted

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>