### PR TITLE
Fix JWT issuer validation for Azure Entra External ID (CIAM)

### DIFF
--- a/fencemark.ApiService/Program.cs
+++ b/fencemark.ApiService/Program.cs
@@ -195,9 +195,14 @@ builder.Services.AddAuthentication(options =>
             options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
             {
                 ValidateIssuer = true,
-                ValidIssuers = new[] 
-                { 
+                ValidIssuers = new[]
+                {
+                    // Custom domain format (e.g., https://devfencemark.ciamlogin.com/{tenantId}/v2.0)
                     $"{instance.TrimEnd('/')}/{tenantId}/v2.0",
+                    // Tenant GUID subdomain format - Azure Entra External ID uses this in tokens
+                    // (e.g., https://{tenantId}.ciamlogin.com/{tenantId}/v2.0)
+                    $"https://{tenantId}.ciamlogin.com/{tenantId}/v2.0",
+                    // Standard Azure AD issuers (fallback)
                     $"https://login.microsoftonline.com/{tenantId}/v2.0",
                     $"https://sts.windows.net/{tenantId}/"
                 },


### PR DESCRIPTION
## Summary
- Fixes 401 Unauthorized errors when authenticating via Azure Entra External ID (CIAM)
- Azure Entra External ID issues tokens with tenant GUID as subdomain (e.g., `https://{tenantId}.ciamlogin.com/{tenantId}/v2.0`) rather than custom domain
- Added the tenant GUID subdomain format to `ValidIssuers` array in JWT Bearer configuration

## Root Cause
The JWT token's issuer claim was:
```
https://153c1433-2dfc-4a35-9aab-52219c3ca071.ciamlogin.com/153c1433-2dfc-4a35-9aab-52219c3ca071/v2.0
```

But the API only accepted:
```
https://devfencemark.ciamlogin.com/{tenantId}/v2.0
```

## Test plan
- [ ] Deploy to dev environment
- [ ] Verify login flow completes successfully
- [ ] Verify API calls return 200 instead of 401
- [ ] Verify user data is returned from `/api/auth/me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)