### PR TITLE
Fix modal dialogs to use MudBlazor overlay pattern

### DIFF
--- a/fencemark.Client/Components/Pages/Components.razor
+++ b/fencemark.Client/Components/Pages/Components.razor
@@ -98,104 +98,122 @@
 
 @if (showModal)
 {
-    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1050; position: fixed; top: 0; left: 0; width: 100%; height: 100%;">
-        <div class="modal-dialog modal-dialog-scrollable" style="max-width: min(800px, calc(100vw - 240px)); margin: 1.75rem auto;">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">@(editingComponent?.Id == null ? "Create" : "Edit") Component</h5>
-                    <button type="button" class="btn-close" @onclick="CloseModal"></button>
-                </div>
-                <div class="modal-body" style="max-height: calc(100vh - 200px); overflow-y: auto;">
-                    @if (!string.IsNullOrEmpty(errorMessage))
+    <MudOverlay Visible="@showModal" DarkBackground="true" ZIndex="1300" LockScroll="true">
+        <MudPaper Class="pa-4 ma-4" Style="max-width: 800px; width: 100%; max-height: calc(100vh - 100px); overflow-y: auto;">
+            <MudText Typo="Typo.h6" Class="mb-4">
+                <MudIcon Icon="@Icons.Material.Filled.Inventory2" Class="mr-2" />
+                @(editingComponent?.Id == null ? "Create" : "Edit") Component
+            </MudText>
+
+            @if (!string.IsNullOrEmpty(errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Class="mb-4">@errorMessage</MudAlert>
+            }
+
+            <MudGrid>
+                <MudItem xs="12" md="8">
+                    <MudTextField Label="Name"
+                                  @bind-Value="editingComponent.Name"
+                                  Required="true"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Placeholder="e.g., 6x6 Pressure Treated Post" />
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudTextField Label="SKU"
+                                  @bind-Value="editingComponent.Sku"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Placeholder="e.g., PT-POST-6X6" />
+                </MudItem>
+            </MudGrid>
+
+            <MudTextField Label="Description"
+                          @bind-Value="editingComponent.Description"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Lines="2"
+                          Class="mt-3"
+                          Placeholder="Additional details about this component" />
+
+            <MudGrid Class="mt-3">
+                <MudItem xs="12" md="6">
+                    <MudSelect Label="Category"
+                               @bind-Value="editingComponent.Category"
+                               Required="true"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense">
+                        <MudSelectItem Value="@("")">Select category...</MudSelectItem>
+                        <MudSelectItem Value="@("Post")">Post</MudSelectItem>
+                        <MudSelectItem Value="@("Rail")">Rail</MudSelectItem>
+                        <MudSelectItem Value="@("Panel")">Panel</MudSelectItem>
+                        <MudSelectItem Value="@("Picket")">Picket</MudSelectItem>
+                        <MudSelectItem Value="@("Hardware")">Hardware</MudSelectItem>
+                        <MudSelectItem Value="@("Gate Hardware")">Gate Hardware</MudSelectItem>
+                        <MudSelectItem Value="@("Fastener")">Fastener</MudSelectItem>
+                        <MudSelectItem Value="@("Concrete")">Concrete</MudSelectItem>
+                        <MudSelectItem Value="@("Stain/Sealer")">Stain/Sealer</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField Label="Material"
+                                  @bind-Value="editingComponent.Material"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Placeholder="e.g., Pressure Treated Pine" />
+                </MudItem>
+            </MudGrid>
+
+            <MudGrid Class="mt-3">
+                <MudItem xs="12" md="4">
+                    <MudTextField Label="Dimensions"
+                                  @bind-Value="editingComponent.Dimensions"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Placeholder="e.g., 6x6x8" />
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudSelect Label="Unit of Measure"
+                               @bind-Value="editingComponent.UnitOfMeasure"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense">
+                        <MudSelectItem Value="@("Each")">Each</MudSelectItem>
+                        <MudSelectItem Value="@("Linear Foot")">Linear Foot</MudSelectItem>
+                        <MudSelectItem Value="@("Board Foot")">Board Foot</MudSelectItem>
+                        <MudSelectItem Value="@("Square Foot")">Square Foot</MudSelectItem>
+                        <MudSelectItem Value="@("Gallon")">Gallon</MudSelectItem>
+                        <MudSelectItem Value="@("Bag")">Bag</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudNumericField Label="Unit Price"
+                                     @bind-Value="editingComponent.UnitPrice"
+                                     T="decimal"
+                                     Variant="Variant.Outlined"
+                                     Margin="Margin.Dense"
+                                     Min="0m"
+                                     Step="0.01m"
+                                     Adornment="Adornment.Start"
+                                     AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+                </MudItem>
+            </MudGrid>
+
+            <div class="d-flex justify-end gap-2 mt-4">
+                <MudButton Variant="Variant.Text" OnClick="CloseModal">Cancel</MudButton>
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           OnClick="SaveComponent"
+                           Disabled="@isSaving">
+                    @if (isSaving)
                     {
-                        <div class="alert alert-danger">@errorMessage</div>
+                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
                     }
-
-                    <div class="row">
-                        <div class="col-md-8 mb-3">
-                            <label class="form-label">Name *</label>
-                            <input type="text" class="form-control" @bind="editingComponent.Name" placeholder="e.g., 6x6 Pressure Treated Post" />
-                        </div>
-                        <div class="col-md-4 mb-3">
-                            <label class="form-label">SKU</label>
-                            <input type="text" class="form-control" @bind="editingComponent.Sku" placeholder="e.g., PT-POST-6X6" />
-                        </div>
-                    </div>
-
-                    <div class="mb-3">
-                        <label class="form-label">Description</label>
-                        <textarea class="form-control" @bind="editingComponent.Description" rows="2" placeholder="Additional details about this component"></textarea>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Category *</label>
-                            <select class="form-select" @bind="editingComponent.Category">
-                                <option value="">Select category...</option>
-                                <option value="Post">Post</option>
-                                <option value="Rail">Rail</option>
-                                <option value="Panel">Panel</option>
-                                <option value="Picket">Picket</option>
-                                <option value="Hardware">Hardware</option>
-                                <option value="Gate Hardware">Gate Hardware</option>
-                                <option value="Fastener">Fastener</option>
-                                <option value="Concrete">Concrete</option>
-                                <option value="Stain/Sealer">Stain/Sealer</option>
-                            </select>
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Material</label>
-                            <input type="text" class="form-control" @bind="editingComponent.Material" placeholder="e.g., Pressure Treated Pine" />
-                        </div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-4 mb-3">
-                            <label class="form-label">Dimensions</label>
-                            <input type="text" class="form-control" @bind="editingComponent.Dimensions" placeholder="e.g., 6x6x8" />
-                        </div>
-                        <div class="col-md-4 mb-3">
-                            <label class="form-label">Unit of Measure *</label>
-                            <select class="form-select" @bind="editingComponent.UnitOfMeasure">
-                                <option value="Each">Each</option>
-                                <option value="Linear Foot">Linear Foot</option>
-                                <option value="Board Foot">Board Foot</option>
-                                <option value="Square Foot">Square Foot</option>
-                                <option value="Gallon">Gallon</option>
-                                <option value="Bag">Bag</option>
-                            </select>
-                        </div>
-                        <div class="col-md-4 mb-3">
-                            <label class="form-label">Unit Price *</label>
-                            <input type="number" step="0.01" class="form-control" @bind="editingComponent.UnitPrice" />
-                        </div>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CloseModal">Cancel</button>
-                    <button type="button" class="btn btn-primary" @onclick="SaveComponent" disabled="@isSaving">
-                        @if (isSaving)
-                        {
-                            <span class="spinner-border spinner-border-sm me-2"></span>
-                        }
-                        Save
-                    </button>
-                </div>
+                    Save
+                </MudButton>
             </div>
-        </div>
-    </div>
+        </MudPaper>
+    </MudOverlay>
 }
-
-<style>
-    .price-cell {
-        font-weight: 600;
-        color: #28a745;
-    }
-
-    .table tbody tr:hover {
-        background-color: #f8f9fa;
-    }
-</style>
 
 @code {
     private List<ComponentDto>? components;

--- a/fencemark.Client/Components/Pages/Fences.razor
+++ b/fencemark.Client/Components/Pages/Fences.razor
@@ -94,85 +94,82 @@ else
     </MudGrid>
 }
 
-@if (showDialog)
-{
-    <MudDialog>
-        <TitleContent>
-            <MudText Typo="Typo.h6">
-                <MudIcon Icon="@Icons.Material.Filled.Fence" Class="mr-2" />
-                @(editingFence?.Id == null ? "Create" : "Edit") Fence Type
-            </MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudForm @ref="form" @bind-IsValid="@formIsValid">
-                <MudTextField Label="Name" 
-                              @bind-Value="editingFence.Name" 
-                              Required="true" 
-                              RequiredError="Name is required"
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              Placeholder="e.g., 6ft Privacy Fence" />
-                
-                <MudTextField Label="Description" 
-                              @bind-Value="editingFence.Description" 
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              Lines="3"
-                              Placeholder="Detailed description of the fence type" />
-                
-                <MudNumericField Label="Height (feet)" 
-                                 @bind-Value="editingFence.HeightInFeet" 
-                                 T="decimal"
-                                 Required="true"
-                                 RequiredError="Height is required"
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 Min="0m"
-                                 Step="0.1m" />
-                
-                <MudNumericField Label="Price per Linear Foot" 
-                                 @bind-Value="editingFence.PricePerLinearFoot" 
-                                 T="decimal"
-                                 Required="true"
-                                 RequiredError="Price is required"
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 Min="0m"
-                                 Step="0.01m"
-                                 Adornment="Adornment.Start"
-                                 AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
-                
-                <MudSelect Label="Material" 
-                           @bind-Value="editingFence.Material" 
-                           Variant="Variant.Outlined"
-                           Margin="Margin.Dense">
-                    <MudSelectItem Value="@("")">Select material...</MudSelectItem>
-                    <MudSelectItem Value="@("Wood")">Wood</MudSelectItem>
-                    <MudSelectItem Value="@("Vinyl")">Vinyl</MudSelectItem>
-                    <MudSelectItem Value="@("Chain Link")">Chain Link</MudSelectItem>
-                    <MudSelectItem Value="@("Aluminum")">Aluminum</MudSelectItem>
-                    <MudSelectItem Value="@("Steel")">Steel</MudSelectItem>
-                    <MudSelectItem Value="@("Composite")">Composite</MudSelectItem>
-                </MudSelect>
-                
-                <MudSelect Label="Style" 
-                           @bind-Value="editingFence.Style" 
-                           Variant="Variant.Outlined"
-                           Margin="Margin.Dense">
-                    <MudSelectItem Value="@("")">Select style...</MudSelectItem>
-                    <MudSelectItem Value="@("Privacy")">Privacy</MudSelectItem>
-                    <MudSelectItem Value="@("Picket")">Picket</MudSelectItem>
-                    <MudSelectItem Value="@("Split Rail")">Split Rail</MudSelectItem>
-                    <MudSelectItem Value="@("Shadowbox")">Shadowbox</MudSelectItem>
-                    <MudSelectItem Value="@("Lattice Top")">Lattice Top</MudSelectItem>
-                </MudSelect>
-            </MudForm>
-        </DialogContent>
-        <DialogActions>
+<MudOverlay Visible="@showDialog" DarkBackground="true" ZIndex="1300" LockScroll="true">
+    <MudPaper Class="pa-4 ma-4" Style="max-width: 600px; width: 100%;">
+        <MudText Typo="Typo.h6" Class="mb-4">
+            <MudIcon Icon="@Icons.Material.Filled.Fence" Class="mr-2" />
+            @(editingFence?.Id == null ? "Create" : "Edit") Fence Type
+        </MudText>
+
+        <MudForm @ref="form" @bind-IsValid="@formIsValid">
+            <MudTextField Label="Name"
+                          @bind-Value="editingFence.Name"
+                          Required="true"
+                          RequiredError="Name is required"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Placeholder="e.g., 6ft Privacy Fence" />
+
+            <MudTextField Label="Description"
+                          @bind-Value="editingFence.Description"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Lines="3"
+                          Placeholder="Detailed description of the fence type" />
+
+            <MudNumericField Label="Height (feet)"
+                             @bind-Value="editingFence.HeightInFeet"
+                             T="decimal"
+                             Required="true"
+                             RequiredError="Height is required"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="0m"
+                             Step="0.1m" />
+
+            <MudNumericField Label="Price per Linear Foot"
+                             @bind-Value="editingFence.PricePerLinearFoot"
+                             T="decimal"
+                             Required="true"
+                             RequiredError="Price is required"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="0m"
+                             Step="0.01m"
+                             Adornment="Adornment.Start"
+                             AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+
+            <MudSelect Label="Material"
+                       @bind-Value="editingFence.Material"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense">
+                <MudSelectItem Value="@("")">Select material...</MudSelectItem>
+                <MudSelectItem Value="@("Wood")">Wood</MudSelectItem>
+                <MudSelectItem Value="@("Vinyl")">Vinyl</MudSelectItem>
+                <MudSelectItem Value="@("Chain Link")">Chain Link</MudSelectItem>
+                <MudSelectItem Value="@("Aluminum")">Aluminum</MudSelectItem>
+                <MudSelectItem Value="@("Steel")">Steel</MudSelectItem>
+                <MudSelectItem Value="@("Composite")">Composite</MudSelectItem>
+            </MudSelect>
+
+            <MudSelect Label="Style"
+                       @bind-Value="editingFence.Style"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense">
+                <MudSelectItem Value="@("")">Select style...</MudSelectItem>
+                <MudSelectItem Value="@("Privacy")">Privacy</MudSelectItem>
+                <MudSelectItem Value="@("Picket")">Picket</MudSelectItem>
+                <MudSelectItem Value="@("Split Rail")">Split Rail</MudSelectItem>
+                <MudSelectItem Value="@("Shadowbox")">Shadowbox</MudSelectItem>
+                <MudSelectItem Value="@("Lattice Top")">Lattice Top</MudSelectItem>
+            </MudSelect>
+        </MudForm>
+
+        <div class="d-flex justify-end gap-2 mt-4">
             <MudButton Variant="Variant.Text" OnClick="CloseDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" 
-                       Color="Color.Primary" 
-                       OnClick="SaveFence" 
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="SaveFence"
                        Disabled="@(!formIsValid || isSaving)">
                 @if (isSaving)
                 {
@@ -180,9 +177,9 @@ else
                 }
                 Save
             </MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+        </div>
+    </MudPaper>
+</MudOverlay>
 
 @code {
     private List<FenceTypeDto>? fences;

--- a/fencemark.Client/Components/Pages/Gates.razor
+++ b/fencemark.Client/Components/Pages/Gates.razor
@@ -98,95 +98,92 @@ else
     </MudGrid>
 }
 
-@if (showDialog)
-{
-    <MudDialog>
-        <TitleContent>
-            <MudText Typo="Typo.h6">
-                <MudIcon Icon="@Icons.Material.Filled.DoorFront" Class="mr-2" />
-                @(editingGate?.Id == null ? "Create" : "Edit") Gate Type
-            </MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudForm @ref="form" @bind-IsValid="@formIsValid">
-                <MudTextField Label="Name" 
-                              @bind-Value="editingGate.Name" 
-                              Required="true" 
-                              RequiredError="Name is required"
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              Placeholder="e.g., 6ft Privacy Gate" />
-                
-                <MudTextField Label="Description" 
-                              @bind-Value="editingGate.Description" 
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              Lines="3"
-                              Placeholder="Detailed description of the gate type" />
-                
-                <MudNumericField Label="Width (feet)" 
-                                 @bind-Value="editingGate.WidthInFeet" 
-                                 T="decimal"
-                                 Required="true"
-                                 RequiredError="Width is required"
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 Min="0m"
-                                 Step="0.1m" />
-                
-                <MudNumericField Label="Height (feet)" 
-                                 @bind-Value="editingGate.HeightInFeet" 
-                                 T="decimal"
-                                 Required="true"
-                                 RequiredError="Height is required"
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 Min="0m"
-                                 Step="0.1m" />
-                
-                <MudNumericField Label="Base Price" 
-                                 @bind-Value="editingGate.BasePrice" 
-                                 T="decimal"
-                                 Required="true"
-                                 RequiredError="Base price is required"
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 Min="0m"
-                                 Step="0.01m"
-                                 Adornment="Adornment.Start"
-                                 AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
-                
-                <MudSelect Label="Material" 
-                           @bind-Value="editingGate.Material" 
-                           Variant="Variant.Outlined"
-                           Margin="Margin.Dense">
-                    <MudSelectItem Value="@("")">Select material...</MudSelectItem>
-                    <MudSelectItem Value="@("Wood")">Wood</MudSelectItem>
-                    <MudSelectItem Value="@("Vinyl")">Vinyl</MudSelectItem>
-                    <MudSelectItem Value="@("Metal")">Metal</MudSelectItem>
-                    <MudSelectItem Value="@("Aluminum")">Aluminum</MudSelectItem>
-                    <MudSelectItem Value="@("Steel")">Steel</MudSelectItem>
-                    <MudSelectItem Value="@("Composite")">Composite</MudSelectItem>
-                </MudSelect>
-                
-                <MudSelect Label="Style" 
-                           @bind-Value="editingGate.Style" 
-                           Variant="Variant.Outlined"
-                           Margin="Margin.Dense">
-                    <MudSelectItem Value="@("")">Select style...</MudSelectItem>
-                    <MudSelectItem Value="@("Walk-through")">Walk-through</MudSelectItem>
-                    <MudSelectItem Value="@("Drive-through")">Drive-through</MudSelectItem>
-                    <MudSelectItem Value="@("Pedestrian")">Pedestrian</MudSelectItem>
-                    <MudSelectItem Value="@("Double")">Double</MudSelectItem>
-                    <MudSelectItem Value="@("Sliding")">Sliding</MudSelectItem>
-                </MudSelect>
-            </MudForm>
-        </DialogContent>
-        <DialogActions>
+<MudOverlay Visible="@showDialog" DarkBackground="true" ZIndex="1300" LockScroll="true">
+    <MudPaper Class="pa-4 ma-4" Style="max-width: 600px; width: 100%;">
+        <MudText Typo="Typo.h6" Class="mb-4">
+            <MudIcon Icon="@Icons.Material.Filled.DoorFront" Class="mr-2" />
+            @(editingGate?.Id == null ? "Create" : "Edit") Gate Type
+        </MudText>
+
+        <MudForm @ref="form" @bind-IsValid="@formIsValid">
+            <MudTextField Label="Name"
+                          @bind-Value="editingGate.Name"
+                          Required="true"
+                          RequiredError="Name is required"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Placeholder="e.g., 6ft Privacy Gate" />
+
+            <MudTextField Label="Description"
+                          @bind-Value="editingGate.Description"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Lines="3"
+                          Placeholder="Detailed description of the gate type" />
+
+            <MudNumericField Label="Width (feet)"
+                             @bind-Value="editingGate.WidthInFeet"
+                             T="decimal"
+                             Required="true"
+                             RequiredError="Width is required"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="0m"
+                             Step="0.1m" />
+
+            <MudNumericField Label="Height (feet)"
+                             @bind-Value="editingGate.HeightInFeet"
+                             T="decimal"
+                             Required="true"
+                             RequiredError="Height is required"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="0m"
+                             Step="0.1m" />
+
+            <MudNumericField Label="Base Price"
+                             @bind-Value="editingGate.BasePrice"
+                             T="decimal"
+                             Required="true"
+                             RequiredError="Base price is required"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="0m"
+                             Step="0.01m"
+                             Adornment="Adornment.Start"
+                             AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+
+            <MudSelect Label="Material"
+                       @bind-Value="editingGate.Material"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense">
+                <MudSelectItem Value="@("")">Select material...</MudSelectItem>
+                <MudSelectItem Value="@("Wood")">Wood</MudSelectItem>
+                <MudSelectItem Value="@("Vinyl")">Vinyl</MudSelectItem>
+                <MudSelectItem Value="@("Metal")">Metal</MudSelectItem>
+                <MudSelectItem Value="@("Aluminum")">Aluminum</MudSelectItem>
+                <MudSelectItem Value="@("Steel")">Steel</MudSelectItem>
+                <MudSelectItem Value="@("Composite")">Composite</MudSelectItem>
+            </MudSelect>
+
+            <MudSelect Label="Style"
+                       @bind-Value="editingGate.Style"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense">
+                <MudSelectItem Value="@("")">Select style...</MudSelectItem>
+                <MudSelectItem Value="@("Walk-through")">Walk-through</MudSelectItem>
+                <MudSelectItem Value="@("Drive-through")">Drive-through</MudSelectItem>
+                <MudSelectItem Value="@("Pedestrian")">Pedestrian</MudSelectItem>
+                <MudSelectItem Value="@("Double")">Double</MudSelectItem>
+                <MudSelectItem Value="@("Sliding")">Sliding</MudSelectItem>
+            </MudSelect>
+        </MudForm>
+
+        <div class="d-flex justify-end gap-2 mt-4">
             <MudButton Variant="Variant.Text" OnClick="CloseDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" 
-                       Color="Color.Primary" 
-                       OnClick="SaveGate" 
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="SaveGate"
                        Disabled="@(!formIsValid || isSaving)">
                 @if (isSaving)
                 {
@@ -194,9 +191,9 @@ else
                 }
                 Save
             </MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+        </div>
+    </MudPaper>
+</MudOverlay>
 
 @code {
     private List<GateTypeDto>? gates;

--- a/fencemark.Client/Components/Pages/Organization.razor
+++ b/fencemark.Client/Components/Pages/Organization.razor
@@ -2,6 +2,7 @@
 @using fencemark.Client.Features.Auth
 @using fencemark.Client.Features.Organization
 @using Microsoft.AspNetCore.Authorization
+@using MudBlazor
 @attribute [Authorize]
 @inject OrganizationApiClient OrgApi
 @inject AuthApiClient AuthApi
@@ -111,89 +112,92 @@
 </div>
 
 <!-- Invite Member Modal -->
-@if (showInviteModal)
-{
-    <div class="modal-backdrop fade show"></div>
-    <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-hidden="false">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Invite Member</h5>
-                    <button type="button" class="btn-close" @onclick="HideInviteModal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <EditForm Model="@inviteModel" OnValidSubmit="@HandleInviteAsync">
-                        <DataAnnotationsValidator />
-                        <div class="mb-3">
-                            <label for="inviteEmail" class="form-label">Email</label>
-                            <InputText id="inviteEmail" @bind-Value="inviteModel.Email" class="form-control" />
-                            <ValidationMessage For="@(() => inviteModel.Email)" />
-                        </div>
-                        <div class="mb-3">
-                            <label for="inviteRole" class="form-label">Role</label>
-                            <InputSelect id="inviteRole" @bind-Value="inviteModel.Role" class="form-select">
-                                <option value="Admin">Admin</option>
-                                <option value="Member">Member</option>
-                                <option value="Billing">Billing</option>
-                                <option value="ReadOnly">Read Only</option>
-                            </InputSelect>
-                            <ValidationMessage For="@(() => inviteModel.Role)" />
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" @onclick="HideInviteModal">Cancel</button>
-                            <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
-                                @if (isSubmitting)
-                                {
-                                    <span class="spinner-border spinner-border-sm me-2"></span>
-                                }
-                                Send Invitation
-                            </button>
-                        </div>
-                    </EditForm>
-                </div>
+<MudOverlay Visible="@showInviteModal" DarkBackground="true" ZIndex="1300" LockScroll="true">
+    <MudPaper Class="pa-4 ma-4" Style="max-width: 500px; width: 100%;">
+        <MudText Typo="Typo.h6" Class="mb-4">
+            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="mr-2" />
+            Invite Member
+        </MudText>
+
+        <EditForm Model="@inviteModel" OnValidSubmit="@HandleInviteAsync">
+            <DataAnnotationsValidator />
+
+            <MudTextField Label="Email"
+                          @bind-Value="inviteModel.Email"
+                          Required="true"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          InputType="InputType.Email"
+                          Class="mb-3" />
+            <ValidationMessage For="@(() => inviteModel.Email)" />
+
+            <MudSelect Label="Role"
+                       @bind-Value="inviteModel.Role"
+                       Required="true"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense">
+                <MudSelectItem Value="@("Admin")">Admin</MudSelectItem>
+                <MudSelectItem Value="@("Member")">Member</MudSelectItem>
+                <MudSelectItem Value="@("Billing")">Billing</MudSelectItem>
+                <MudSelectItem Value="@("ReadOnly")">Read Only</MudSelectItem>
+            </MudSelect>
+            <ValidationMessage For="@(() => inviteModel.Role)" />
+
+            <div class="d-flex justify-end gap-2 mt-4">
+                <MudButton Variant="Variant.Text" OnClick="HideInviteModal">Cancel</MudButton>
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           ButtonType="ButtonType.Submit"
+                           Disabled="@isSubmitting">
+                    @if (isSubmitting)
+                    {
+                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                    }
+                    Send Invitation
+                </MudButton>
             </div>
-        </div>
-    </div>
-}
+        </EditForm>
+    </MudPaper>
+</MudOverlay>
 
 <!-- Change Role Modal -->
-@if (showRoleModal && selectedMember != null)
-{
-    <div class="modal-backdrop fade show"></div>
-    <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-hidden="false">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Change Role for @selectedMember.Email</h5>
-                    <button type="button" class="btn-close" @onclick="HideRoleModal" aria-label="Close"></button>
+<MudOverlay Visible="@showRoleModal" DarkBackground="true" ZIndex="1300" LockScroll="true">
+    @if (selectedMember != null)
+    {
+        <MudPaper Class="pa-4 ma-4" Style="max-width: 500px; width: 100%;">
+            <MudText Typo="Typo.h6" Class="mb-4">
+                <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="mr-2" />
+                Change Role for @selectedMember.Email
+            </MudText>
+
+            <EditForm Model="@roleModel" OnValidSubmit="@HandleRoleChangeAsync">
+                <MudSelect Label="New Role"
+                           @bind-Value="roleModel.Role"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
+                    <MudSelectItem Value="@("Admin")">Admin</MudSelectItem>
+                    <MudSelectItem Value="@("Member")">Member</MudSelectItem>
+                    <MudSelectItem Value="@("Billing")">Billing</MudSelectItem>
+                    <MudSelectItem Value="@("ReadOnly")">Read Only</MudSelectItem>
+                </MudSelect>
+
+                <div class="d-flex justify-end gap-2 mt-4">
+                    <MudButton Variant="Variant.Text" OnClick="HideRoleModal">Cancel</MudButton>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               ButtonType="ButtonType.Submit"
+                               Disabled="@isSubmitting">
+                        @if (isSubmitting)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                        }
+                        Update Role
+                    </MudButton>
                 </div>
-                <div class="modal-body">
-                    <EditForm Model="@roleModel" OnValidSubmit="@HandleRoleChangeAsync">
-                        <div class="mb-3">
-                            <label for="newRole" class="form-label">New Role</label>
-                            <InputSelect id="newRole" @bind-Value="roleModel.Role" class="form-select">
-                                <option value="Admin">Admin</option>
-                                <option value="Member">Member</option>
-                                <option value="Billing">Billing</option>
-                                <option value="ReadOnly">Read Only</option>
-                            </InputSelect>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" @onclick="HideRoleModal">Cancel</button>
-                            <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
-                                @if (isSubmitting)
-                                {
-                                    <span class="spinner-border spinner-border-sm me-2"></span>
-                                }
-                                Update Role
-                            </button>
-                        </div>
-                    </EditForm>
-                </div>
-            </div>
-        </div>
-    </div>
-}
+            </EditForm>
+        </MudPaper>
+    }
+</MudOverlay>
 
 @code {
     private List<OrganizationMemberResponse>? members;


### PR DESCRIPTION
## Summary
- Fixes modal dialogs across 4 pages that were either rendering inline without backdrop (Fences, Gates) or using Bootstrap instead of MudBlazor (Components, Organization)
- All modals now use consistent MudOverlay + MudPaper pattern with proper dark backdrop

## Issues Fixed
- #148 - Fences page dialog renders inline without modal overlay
- #149 - Gates page dialog renders inline without modal overlay
- #150 - Components page modal uses Bootstrap instead of MudBlazor
- #151 - Organization page modals use Bootstrap instead of MudBlazor

## Changes Made
| File | Change |
|------|--------|
| Fences.razor | Wrapped MudDialog content with MudOverlay + MudPaper |
| Gates.razor | Wrapped MudDialog content with MudOverlay + MudPaper |
| Components.razor | Converted Bootstrap modal to MudBlazor (MudOverlay, MudPaper, MudTextField, MudSelect, MudNumericField) |
| Organization.razor | Converted 2 Bootstrap modals (Invite Member, Change Role) to MudBlazor |

## Test plan
- [ ] Verify Fences page "Add Fence Type" button opens modal with dark backdrop
- [ ] Verify Gates page "Add Gate Type" button opens modal with dark backdrop
- [ ] Verify Components page "Add Component" button opens modal with proper MudBlazor styling
- [ ] Verify Organization page "Invite Member" button opens styled modal
- [ ] Verify Organization page "Change Role" button opens styled modal
- [ ] Verify all modals can be closed via Cancel button
- [ ] Verify form validation works in all modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)