### PR TITLE
Fix Jobs page modal to use MudBlazor overlay pattern

### DIFF
--- a/fencemark.Client/Components/Layout/MainLayout.razor
+++ b/fencemark.Client/Components/Layout/MainLayout.razor
@@ -43,6 +43,12 @@
                             Gates
                         </div>
                     </a>
+                    <a href="/organization" class="@(IsActive("/organization") || IsActive("/settings/organization") ? "active" : "")">
+                        <div class="flex items-center gap-2">
+                            <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Small" />
+                            Organization
+                        </div>
+                    </a>
                 </nav>
                 
                 <div class="flex items-center gap-3 modern-nav-actions">

--- a/fencemark.Client/Components/Pages/Jobs.razor
+++ b/fencemark.Client/Components/Pages/Jobs.razor
@@ -131,110 +131,158 @@
     }
 </div>
 
-@if (showModal)
-{
-    <div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5); z-index: 1050; position: fixed; top: 0; left: 0; width: 100%; height: 100%;">
-        <div class="modal-dialog modal-dialog-scrollable" style="max-width: min(800px, calc(100vw - 240px)); margin: 1.75rem auto;">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">@(editingJob?.Id == null ? "Create" : "Edit") Job</h5>
-                    <button type="button" class="btn-close" @onclick="CloseModal"></button>
-                </div>
-                <div class="modal-body" style="max-height: calc(100vh - 200px); overflow-y: auto;">
-                    @if (!string.IsNullOrEmpty(errorMessage))
+<MudOverlay Visible="@showModal" DarkBackground="true" ZIndex="1300" LockScroll="true">
+    <MudPaper Class="pa-4 ma-4" Style="max-width: 800px; width: 100%; max-height: calc(100vh - 100px); overflow-y: auto;">
+        <MudText Typo="Typo.h6" Class="mb-4">
+            <MudIcon Icon="@Icons.Material.Filled.Work" Class="mr-2" />
+            @(editingJob?.Id == null ? "Create" : "Edit") Job
+        </MudText>
+
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-4">@errorMessage</MudAlert>
+        }
+
+        <MudGrid>
+            <MudItem xs="12" md="6">
+                <MudTextField Label="Job Name"
+                              @bind-Value="editingJob.Name"
+                              Required="true"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Placeholder="e.g., Smith Backyard Fence" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudSelect Label="Status"
+                           @bind-Value="editingJob.Status"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
+                    @foreach (JobStatusDto status in Enum.GetValues(typeof(JobStatusDto)))
                     {
-                        <div class="alert alert-danger">@errorMessage</div>
+                        <MudSelectItem Value="@status">@GetStatusDisplayName(status)</MudSelectItem>
                     }
+                </MudSelect>
+            </MudItem>
+        </MudGrid>
 
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Job Name *</label>
-                            <input type="text" class="form-control" @bind="editingJob.Name" placeholder="e.g., Smith Backyard Fence" />
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Status</label>
-                            <select class="form-select" @bind="editingJob.Status">
-                                @foreach (JobStatusDto status in Enum.GetValues(typeof(JobStatusDto)))
-                                {
-                                    <option value="@status">@status</option>
-                                }
-                            </select>
-                        </div>
-                    </div>
+        <MudText Typo="Typo.subtitle1" Class="mt-4 mb-2">Customer Information</MudText>
+        <MudGrid>
+            <MudItem xs="12" md="6">
+                <MudTextField Label="Customer Name"
+                              @bind-Value="editingJob.CustomerName"
+                              Required="true"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField Label="Customer Email"
+                              @bind-Value="editingJob.CustomerEmail"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              InputType="InputType.Email" />
+            </MudItem>
+        </MudGrid>
 
-                    <h6 class="mt-3">Customer Information</h6>
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Customer Name *</label>
-                            <input type="text" class="form-control" @bind="editingJob.CustomerName" />
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Customer Email</label>
-                            <input type="email" class="form-control" @bind="editingJob.CustomerEmail" />
-                        </div>
-                    </div>
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" md="6">
+                <MudTextField Label="Customer Phone"
+                              @bind-Value="editingJob.CustomerPhone"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              InputType="InputType.Telephone" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField Label="Installation Address"
+                              @bind-Value="editingJob.InstallationAddress"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+            </MudItem>
+        </MudGrid>
 
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Customer Phone</label>
-                            <input type="tel" class="form-control" @bind="editingJob.CustomerPhone" />
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Installation Address</label>
-                            <input type="text" class="form-control" @bind="editingJob.InstallationAddress" />
-                        </div>
-                    </div>
+        <MudText Typo="Typo.subtitle1" Class="mt-4 mb-2">Job Details</MudText>
+        <MudGrid>
+            <MudItem xs="12" md="3">
+                <MudNumericField Label="Total Linear Feet"
+                                 @bind-Value="editingJob.TotalLinearFeet"
+                                 T="decimal"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Min="0m"
+                                 Step="0.1m" />
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudNumericField Label="Materials Cost"
+                                 @bind-Value="editingJob.MaterialsCost"
+                                 T="decimal"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Min="0m"
+                                 Step="0.01m"
+                                 Adornment="Adornment.Start"
+                                 AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudNumericField Label="Labor Cost"
+                                 @bind-Value="editingJob.LaborCost"
+                                 T="decimal"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Min="0m"
+                                 Step="0.01m"
+                                 Adornment="Adornment.Start"
+                                 AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudNumericField Label="Total Cost"
+                                 @bind-Value="editingJob.TotalCost"
+                                 T="decimal"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Min="0m"
+                                 Step="0.01m"
+                                 Adornment="Adornment.Start"
+                                 AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+            </MudItem>
+        </MudGrid>
 
-                    <h6 class="mt-3">Job Details</h6>
-                    <div class="row">
-                        <div class="col-md-3 mb-3">
-                            <label class="form-label">Total Linear Feet</label>
-                            <input type="number" step="0.1" class="form-control" @bind="editingJob.TotalLinearFeet" />
-                        </div>
-                        <div class="col-md-3 mb-3">
-                            <label class="form-label">Materials Cost</label>
-                            <input type="number" step="0.01" class="form-control" @bind="editingJob.MaterialsCost" />
-                        </div>
-                        <div class="col-md-3 mb-3">
-                            <label class="form-label">Labor Cost</label>
-                            <input type="number" step="0.01" class="form-control" @bind="editingJob.LaborCost" />
-                        </div>
-                        <div class="col-md-3 mb-3">
-                            <label class="form-label">Total Cost</label>
-                            <input type="number" step="0.01" class="form-control" @bind="editingJob.TotalCost" />
-                        </div>
-                    </div>
+        <MudGrid Class="mt-2">
+            <MudItem xs="12" md="6">
+                <MudDatePicker Label="Estimated Start Date"
+                               @bind-Date="editingJob.EstimatedStartDate"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudDatePicker Label="Estimated Completion Date"
+                               @bind-Date="editingJob.EstimatedCompletionDate"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense" />
+            </MudItem>
+        </MudGrid>
 
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Estimated Start Date</label>
-                            <input type="date" class="form-control" @bind="editingJob.EstimatedStartDate" />
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label class="form-label">Estimated Completion Date</label>
-                            <input type="date" class="form-control" @bind="editingJob.EstimatedCompletionDate" />
-                        </div>
-                    </div>
+        <MudTextField Label="Notes"
+                      @bind-Value="editingJob.Notes"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      Lines="3"
+                      Class="mt-3"
+                      Placeholder="Additional notes about the job" />
 
-                    <div class="mb-3">
-                        <label class="form-label">Notes</label>
-                        <textarea class="form-control" @bind="editingJob.Notes" rows="3" placeholder="Additional notes about the job"></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CloseModal">Cancel</button>
-                    <button type="button" class="btn btn-primary" @onclick="SaveJob" disabled="@isSaving">
-                        @if (isSaving)
-                        {
-                            <span class="spinner-border spinner-border-sm me-2"></span>
-                        }
-                        Save
-                    </button>
-                </div>
-            </div>
+        <div class="d-flex justify-end gap-2 mt-4">
+            <MudButton Variant="Variant.Text" OnClick="CloseModal">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="SaveJob"
+                       Disabled="@isSaving">
+                @if (isSaving)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                }
+                Save
+            </MudButton>
         </div>
-    </div>
-}
+    </MudPaper>
+</MudOverlay>
 
 @code {
     private List<JobDto>? jobs;

--- a/fencemark.Client/Components/Pages/Organization.razor
+++ b/fencemark.Client/Components/Pages/Organization.razor
@@ -16,9 +16,20 @@
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2 class="m-0">Organization Members</h2>
-                <button class="btn btn-success ms-3" @onclick="ShowInviteModal">
-                    <i class="bi bi-person-plus"></i> Invite Member
-                </button>
+                <div class="d-flex gap-2">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Settings"
+                               Href="/settings/organization">
+                        Settings
+                    </MudButton>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Success"
+                               StartIcon="@Icons.Material.Filled.PersonAdd"
+                               OnClick="ShowInviteModal">
+                        Invite Member
+                    </MudButton>
+                </div>
             </div>
 
             @if (isLoading)


### PR DESCRIPTION
## Summary
- Converts Bootstrap modal on Jobs page to use MudBlazor components for consistent styling
- Adds missing Organization link to main navigation header
- Adds Settings button on Organization Members page

## Issues Fixed
- #153 - Jobs page modal uses Bootstrap instead of MudBlazor
- #155 - Organization link missing from main navigation

## Changes Made

### Jobs Modal (Jobs.razor)
| Component | Before | After |
|-----------|--------|-------|
| Modal container | Bootstrap `modal` classes | `MudOverlay` + `MudPaper` |
| Text inputs | `<input class="form-control">` | `MudTextField` |
| Number inputs | `<input type="number">` | `MudNumericField` with $ adornment |
| Select | `<select class="form-select">` | `MudSelect` |
| Date inputs | `<input type="date">` | `MudDatePicker` |
| Error display | Bootstrap alert | `MudAlert` |
| Buttons | Bootstrap buttons | `MudButton` |

### Navigation (MainLayout.razor)
- Added "Organization" link with business icon to main nav header
- Link highlights when on `/organization` or `/settings/organization`

### Organization Page (Organization.razor)
- Added "Settings" button to navigate to Organization Settings page
- Converted header buttons to MudButton for consistency

## Test plan
- [ ] Verify "New Job" button opens modal with dark backdrop
- [ ] Verify all form fields work correctly (text, numbers, dates, select)
- [ ] Verify Cancel closes modal
- [ ] Verify Save creates/updates job
- [ ] Verify Organization link appears in main navigation
- [ ] Verify clicking Organization link navigates to `/organization`
- [ ] Verify Settings button on Organization page navigates to `/settings/organization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)