### PR TITLE
[Critical] Disable PII logging outside Development

### DIFF
--- a/fencemark.ApiService/Infrastructure/LoggingHelper.cs
+++ b/fencemark.ApiService/Infrastructure/LoggingHelper.cs
@@ -34,6 +34,16 @@ public static partial class LoggingHelper
     }
 
     /// <summary>
+    /// Determines whether the Microsoft.IdentityModel PII (personally identifiable information)
+    /// logging switch should be enabled. This must only ever be true in Development, since
+    /// enabling it in Production logs emails, names, and other claims from JWT tokens.
+    /// </summary>
+    public static bool ShouldEnablePiiLogging(bool isDevelopment)
+    {
+        return isDevelopment;
+    }
+
+    /// <summary>
     /// Masks sensitive data in a connection string for safe logging
     /// </summary>
     public static string MaskConnectionString(string? connectionString)

--- a/fencemark.ApiService/Program.cs
+++ b/fencemark.ApiService/Program.cs
@@ -244,8 +244,10 @@ builder.Services.AddAuthentication(options =>
             Console.WriteLine($"[ApiService] Using Authority: {options.Authority}");
             Console.WriteLine($"[ApiService] Accepted Audiences: api://{audience}, {audience}");
             
-            // Enable detailed PII logging for debugging
-            Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII = true;
+            // Enable detailed PII logging for debugging - Development only, never in Production
+            // (PII logging exposes emails, names, and other JWT claims in logs)
+            Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII =
+                fencemark.ApiService.Infrastructure.LoggingHelper.ShouldEnablePiiLogging(builder.Environment.IsDevelopment());
             
             options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
             {

--- a/fencemark.Tests/LoggingHelperTests.cs
+++ b/fencemark.Tests/LoggingHelperTests.cs
@@ -246,4 +246,24 @@ public class LoggingHelperTests
         Assert.Contains("Password=***", masked);
         Assert.Contains("User Id=***", masked);
     }
+
+    [Fact]
+    public void ShouldEnablePiiLogging_WhenDevelopment_ReturnsTrue()
+    {
+        // Act
+        var result = LoggingHelper.ShouldEnablePiiLogging(isDevelopment: true);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldEnablePiiLogging_WhenNotDevelopment_ReturnsFalse()
+    {
+        // Act
+        var result = LoggingHelper.ShouldEnablePiiLogging(isDevelopment: false);
+
+        // Assert
+        Assert.False(result, "PII logging must never be enabled outside Development - it exposes emails, names, and other JWT claims in logs.");
+    }
 }


### PR DESCRIPTION
## Summary
- `IdentityModelEventSource.ShowPII` was unconditionally set to `true` in `Program.cs`, so JWT claims (emails, names, etc.) were logged in Production.
- Extracted the on/off decision into `LoggingHelper.ShouldEnablePiiLogging(bool isDevelopment)` and gated the flag on `builder.Environment.IsDevelopment()`.

## Test plan
- [x] Added `LoggingHelperTests.ShouldEnablePiiLogging_WhenDevelopment_ReturnsTrue` / `_WhenNotDevelopment_ReturnsFalse` unit tests
- [x] `dotnet build fencemark.ApiService` succeeds
- [x] `dotnet test fencemark.Tests --filter-class "*LoggingHelperTests*"` — 24/24 passed

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)