### PR TITLE
[High] Use cryptographically secure invitation tokens

### DIFF
--- a/fencemark.ApiService/Infrastructure/SecureTokenGenerator.cs
+++ b/fencemark.ApiService/Infrastructure/SecureTokenGenerator.cs
@@ -1,0 +1,26 @@
+using System.Security.Cryptography;
+
+namespace fencemark.ApiService.Infrastructure;
+
+/// <summary>
+/// Generates cryptographically secure, URL-safe tokens (e.g. for invitation links),
+/// as opposed to GUIDs which are not designed to be unguessable.
+/// </summary>
+public static class SecureTokenGenerator
+{
+    private const int DefaultByteLength = 32;
+
+    /// <summary>
+    /// Generates a cryptographically secure, URL-safe (base64url, unpadded) token.
+    /// </summary>
+    /// <param name="byteLength">Number of random bytes of entropy backing the token.</param>
+    public static string Generate(int byteLength = DefaultByteLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(byteLength, 0);
+
+        return Convert.ToBase64String(RandomNumberGenerator.GetBytes(byteLength))
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+}

--- a/fencemark.ApiService/Services/OrganizationService.cs
+++ b/fencemark.ApiService/Services/OrganizationService.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -259,7 +260,7 @@ public class OrganizationService(
         }
 
         // Generate invitation token
-        var invitationToken = Guid.NewGuid().ToString();
+        var invitationToken = SecureTokenGenerator.Generate();
 
         if (existingUser is not null)
         {

--- a/fencemark.Tests/OrganizationServiceTests.cs
+++ b/fencemark.Tests/OrganizationServiceTests.cs
@@ -114,6 +114,8 @@ public class OrganizationServiceTests
         // Assert
         Assert.True(response.Success);
         Assert.NotNull(response.InvitationToken);
+        Assert.False(Guid.TryParse(response.InvitationToken, out _),
+            "Invitation tokens must be cryptographically secure, not GUIDs.");
 
         var membership = await context.OrganizationMembers
             .FirstOrDefaultAsync(m => m.OrganizationId == org.Id && m.InvitationToken == response.InvitationToken);

--- a/fencemark.Tests/SecureTokenGeneratorTests.cs
+++ b/fencemark.Tests/SecureTokenGeneratorTests.cs
@@ -1,0 +1,73 @@
+using System.Text.RegularExpressions;
+using fencemark.ApiService.Infrastructure;
+using Xunit;
+
+namespace fencemark.Tests;
+
+public class SecureTokenGeneratorTests
+{
+    [Fact]
+    public void Generate_ReturnsNonEmptyToken()
+    {
+        var token = SecureTokenGenerator.Generate();
+
+        Assert.False(string.IsNullOrWhiteSpace(token));
+    }
+
+    [Fact]
+    public void Generate_ReturnsUrlSafeCharactersOnly()
+    {
+        var token = SecureTokenGenerator.Generate();
+
+        Assert.Matches(new Regex("^[A-Za-z0-9_-]+$"), token);
+        Assert.DoesNotContain("+", token);
+        Assert.DoesNotContain("/", token);
+        Assert.DoesNotContain("=", token);
+    }
+
+    [Fact]
+    public void Generate_MultipleCalls_ProduceUniqueTokens()
+    {
+        var tokens = Enumerable.Range(0, 1000).Select(_ => SecureTokenGenerator.Generate()).ToList();
+
+        Assert.Equal(tokens.Count, tokens.Distinct().Count());
+    }
+
+    [Fact]
+    public void Generate_DefaultLength_HasMoreEntropyThanAGuid()
+    {
+        // A GUID has 122 bits of usable entropy (~36 chars incl. hyphens).
+        // The default 32-byte token has 256 bits of entropy, encoded as ~43 base64url chars.
+        var token = SecureTokenGenerator.Generate();
+
+        Assert.True(token.Length > 36, $"Expected token longer than a GUID's 36 characters, got {token.Length}");
+    }
+
+    [Theory]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(64)]
+    public void Generate_WithCustomByteLength_ScalesTokenLength(int byteLength)
+    {
+        var token = SecureTokenGenerator.Generate(byteLength);
+
+        // Unpadded base64 length is ceil(byteLength * 4 / 3)
+        var expectedLength = (int)Math.Ceiling(byteLength * 4 / 3.0);
+        Assert.Equal(expectedLength, token.Length);
+    }
+
+    [Fact]
+    public void Generate_WithZeroOrNegativeLength_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => SecureTokenGenerator.Generate(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => SecureTokenGenerator.Generate(-1));
+    }
+
+    [Fact]
+    public void Generate_DoesNotProduceAGuidFormattedString()
+    {
+        var token = SecureTokenGenerator.Generate();
+
+        Assert.False(Guid.TryParse(token, out _), "Invitation tokens must not be GUIDs - they are not cryptographically secure.");
+    }
+}


### PR DESCRIPTION
## Summary
- `OrganizationService.InviteUserAsync` generated invitation tokens with `Guid.NewGuid()`, which is not designed to be unguessable.
- Added `SecureTokenGenerator.Generate()` (Infrastructure), producing a 256-bit random, URL-safe base64 token via `RandomNumberGenerator`, and swapped it in.

## Test plan
- [x] Added `SecureTokenGeneratorTests` covering: non-empty, URL-safe charset, uniqueness across 1000 generations, length scaling with byte count, rejects invalid lengths, and confirms output is never GUID-shaped
- [x] Extended `OrganizationServiceTests.WhenAdminInvitesUserInvitationIsCreated` to assert the returned token is not a parseable GUID (regression guard)
- [x] `dotnet build fencemark.ApiService` succeeds
- [x] `dotnet test fencemark.Tests --filter-class "*SecureTokenGeneratorTests*" --filter-class "*OrganizationServiceTests*"` — 17/17 passed

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)