### PR TITLE
[High] Add role-based authorization for destructive/admin operations

### DIFF
--- a/fencemark.ApiService/Features/Components/ComponentEndpoints.cs
+++ b/fencemark.ApiService/Features/Components/ComponentEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using fencemark.ApiService.Services;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,7 @@ public static class ComponentEndpoints
             .WithName("UpdateComponent");
 
         group.MapDelete("/{id}", DeleteComponent)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteComponent");
 
         return app;

--- a/fencemark.ApiService/Features/Discounts/DiscountEndpoints.cs
+++ b/fencemark.ApiService/Features/Discounts/DiscountEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +27,7 @@ public static class DiscountEndpoints
             .WithName("UpdateDiscount");
 
         group.MapDelete("/{id}", DeleteDiscount)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteDiscount");
 
         group.MapPost("/validate-promo", ValidatePromoCode)

--- a/fencemark.ApiService/Features/Fences/FenceEndpoints.cs
+++ b/fencemark.ApiService/Features/Fences/FenceEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using fencemark.ApiService.Services;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,7 @@ public static class FenceEndpoints
             .WithName("UpdateFenceType");
 
         group.MapDelete("/{id}", DeleteFence)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteFenceType");
 
         return app;

--- a/fencemark.ApiService/Features/Gates/GateEndpoints.cs
+++ b/fencemark.ApiService/Features/Gates/GateEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using fencemark.ApiService.Services;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,7 @@ public static class GateEndpoints
             .WithName("UpdateGateType");
 
         group.MapDelete("/{id}", DeleteGate)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteGateType");
 
         return app;

--- a/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
+++ b/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using fencemark.ApiService.Services;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,7 @@ public static class JobEndpoints
             .WithName("UpdateJob");
 
         group.MapDelete("/{id}", DeleteJob)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteJob");
 
         return app;

--- a/fencemark.ApiService/Features/Organization/OrganizationEndpoints.cs
+++ b/fencemark.ApiService/Features/Organization/OrganizationEndpoints.cs
@@ -1,3 +1,4 @@
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using fencemark.ApiService.Services;
 
@@ -15,7 +16,7 @@ public static class OrganizationEndpoints
             .WithName("CreateOrganization");
 
         group.MapPut("/{organizationId}", UpdateOrganization)
-            .RequireAuthorization()
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("UpdateOrganization");
 
         group.MapGet("/{organizationId}/members", GetMembers)
@@ -23,18 +24,18 @@ public static class OrganizationEndpoints
             .WithName("GetOrganizationMembers");
 
         group.MapPost("/{organizationId}/invite", InviteUser)
-            .RequireAuthorization()
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("InviteUser");
 
         group.MapPost("/accept-invitation", AcceptInvitation)
             .WithName("AcceptInvitation");
 
         group.MapPut("/{organizationId}/members/role", UpdateRole)
-            .RequireAuthorization()
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("UpdateMemberRole");
 
         group.MapDelete("/{organizationId}/members/{userId}", RemoveMember)
-            .RequireAuthorization()
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("RemoveMember");
 
         group.MapPost("/seed-sample-data", SeedSampleData)

--- a/fencemark.ApiService/Features/Pricing/PricingEndpoints.cs
+++ b/fencemark.ApiService/Features/Pricing/PricingEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +27,7 @@ public static class PricingEndpoints
             .WithName("UpdatePricingConfig");
 
         group.MapDelete("/{id}", DeletePricingConfig)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeletePricingConfig");
 
         return app;

--- a/fencemark.ApiService/Features/TaxRegions/TaxRegionEndpoints.cs
+++ b/fencemark.ApiService/Features/TaxRegions/TaxRegionEndpoints.cs
@@ -1,5 +1,6 @@
 using fencemark.ApiService.Data;
 using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Infrastructure;
 using fencemark.ApiService.Middleware;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,6 +27,7 @@ public static class TaxRegionEndpoints
             .WithName("UpdateTaxRegion");
 
         group.MapDelete("/{id}", DeleteTaxRegion)
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly)
             .WithName("DeleteTaxRegion");
 
         return app;

--- a/fencemark.ApiService/Infrastructure/AuthorizationPolicies.cs
+++ b/fencemark.ApiService/Infrastructure/AuthorizationPolicies.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace fencemark.ApiService.Infrastructure;
+
+/// <summary>
+/// Centralizes the authorization policy names and role requirements used across endpoints,
+/// so the same definition is used both when registering policies and when testing them.
+/// </summary>
+public static class AuthorizationPolicies
+{
+    /// <summary>
+    /// Policy for destructive or organization-management operations that should be
+    /// restricted to organization Owners and Admins (not regular Members).
+    /// </summary>
+    public const string AdminOnly = "AdminOnly";
+
+    /// <summary>
+    /// Roles satisfying the <see cref="AdminOnly"/> policy.
+    /// </summary>
+    public static readonly string[] AdminOnlyRoles = ["Owner", "Admin"];
+
+    /// <summary>
+    /// Registers all fencemark authorization policies on the given options.
+    /// </summary>
+    public static void AddFencemarkPolicies(this AuthorizationOptions options)
+    {
+        options.AddPolicy(AdminOnly, policy => policy.RequireAuthenticatedUser().RequireRole(AdminOnlyRoles));
+    }
+}

--- a/fencemark.ApiService/Middleware/CurrentUserService.cs
+++ b/fencemark.ApiService/Middleware/CurrentUserService.cs
@@ -11,6 +11,7 @@ public interface ICurrentUserService
     string? UserId { get; }
     string? Email { get; }
     string? OrganizationId { get; }
+    string? Role { get; }
     bool IsAuthenticated { get; }
 }
 
@@ -49,6 +50,9 @@ public class CurrentUserService : ICurrentUserService
         ?? _httpContextAccessor.HttpContext?.User?.FindFirstValue("email");
 
     public bool IsAuthenticated => _httpContextAccessor.HttpContext?.User?.Identity?.IsAuthenticated ?? false;
+
+    public string? Role =>
+        _httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.Role);
 
     public string? OrganizationId
     {

--- a/fencemark.ApiService/Program.cs
+++ b/fencemark.ApiService/Program.cs
@@ -425,9 +425,13 @@ builder.Services.AddAuthentication(options =>
                         
                         if (membership != null)
                         {
-                            // Add OrganizationId claim to the principal
+                            // Add OrganizationId and Role claims to the principal.
+                            // Role uses the standard ClaimTypes.Role so ASP.NET Core's
+                            // role-based authorization (RequireRole/IsInRole) works without
+                            // extra configuration.
                             claims.Add(new Claim(CustomClaimTypes.OrganizationId, membership.OrganizationId));
-                            logger.LogInformation("[ApiService] Added ApplicationUserId and OrganizationId claims: UserId={UserId}, OrgId={OrgId}", user.Id, membership.OrganizationId);
+                            claims.Add(new Claim(ClaimTypes.Role, membership.Role.ToString()));
+                            logger.LogInformation("[ApiService] Added ApplicationUserId, OrganizationId, and Role claims: UserId={UserId}, OrgId={OrgId}, Role={Role}", user.Id, membership.OrganizationId, membership.Role);
                         }
                         else
                         {
@@ -509,7 +513,7 @@ builder.Services.Configure<AzureMapsOptions>(builder.Configuration.GetSection(Az
 builder.Services.AddSingleton<IAzureMapsTokenService, AzureMapsTokenService>();
 
 // Add authorization
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options => options.AddFencemarkPolicies());
 
 var app = builder.Build();
 

--- a/fencemark.Tests/AuthorizationPoliciesTests.cs
+++ b/fencemark.Tests/AuthorizationPoliciesTests.cs
@@ -1,0 +1,84 @@
+using System.Security.Claims;
+using fencemark.ApiService.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Exercises the real ASP.NET Core authorization pipeline wired up exactly as Program.cs
+/// configures it, to guard against the AdminOnly policy silently allowing non-admin roles.
+/// </summary>
+public class AuthorizationPoliciesTests
+{
+    private static IAuthorizationService CreateAuthorizationService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthorization(options => options.AddFencemarkPolicies());
+        return services.BuildServiceProvider().GetRequiredService<IAuthorizationService>();
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(string? role)
+    {
+        var claims = new List<Claim>();
+        if (role != null)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var identity = new ClaimsIdentity(claims, authenticationType: "TestAuth");
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Theory]
+    [InlineData("Owner")]
+    [InlineData("Admin")]
+    public async Task AdminOnlyPolicy_WithOwnerOrAdminRole_Succeeds(string role)
+    {
+        var authorizationService = CreateAuthorizationService();
+        var principal = CreatePrincipal(role);
+
+        var result = await authorizationService.AuthorizeAsync(principal, AuthorizationPolicies.AdminOnly);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData("Member")]
+    [InlineData("Billing")]
+    [InlineData("ReadOnly")]
+    public async Task AdminOnlyPolicy_WithNonAdminRole_Fails(string role)
+    {
+        var authorizationService = CreateAuthorizationService();
+        var principal = CreatePrincipal(role);
+
+        var result = await authorizationService.AuthorizeAsync(principal, AuthorizationPolicies.AdminOnly);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AdminOnlyPolicy_WithNoRoleClaim_Fails()
+    {
+        var authorizationService = CreateAuthorizationService();
+        var principal = CreatePrincipal(role: null);
+
+        var result = await authorizationService.AuthorizeAsync(principal, AuthorizationPolicies.AdminOnly);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AdminOnlyPolicy_WithUnauthenticatedPrincipal_Fails()
+    {
+        var authorizationService = CreateAuthorizationService();
+        // No authenticationType => IsAuthenticated is false, mirroring an anonymous request.
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "Owner") }));
+
+        var result = await authorizationService.AuthorizeAsync(principal, AuthorizationPolicies.AdminOnly);
+
+        Assert.False(result.Succeeded);
+    }
+}

--- a/fencemark.Tests/CurrentUserServiceTests.cs
+++ b/fencemark.Tests/CurrentUserServiceTests.cs
@@ -1,0 +1,70 @@
+using System.Security.Claims;
+using fencemark.ApiService.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace fencemark.Tests;
+
+public class CurrentUserServiceTests
+{
+    private static CurrentUserService CreateService(ClaimsPrincipal? principal)
+    {
+        var accessor = new HttpContextAccessor();
+        if (principal != null)
+        {
+            accessor.HttpContext = new DefaultHttpContext { User = principal };
+        }
+
+        var logger = new Logger<CurrentUserService>(new LoggerFactory());
+        return new CurrentUserService(accessor, logger);
+    }
+
+    private static ClaimsPrincipal CreateAuthenticatedPrincipal(params Claim[] claims)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "TestAuth"));
+    }
+
+    [Fact]
+    public void Role_WithRoleClaim_ReturnsRole()
+    {
+        var principal = CreateAuthenticatedPrincipal(new Claim(ClaimTypes.Role, "Admin"));
+        var service = CreateService(principal);
+
+        Assert.Equal("Admin", service.Role);
+    }
+
+    [Fact]
+    public void Role_WithoutRoleClaim_ReturnsNull()
+    {
+        var principal = CreateAuthenticatedPrincipal(new Claim(ClaimTypes.Name, "test@example.com"));
+        var service = CreateService(principal);
+
+        Assert.Null(service.Role);
+    }
+
+    [Fact]
+    public void Role_WithNoHttpContext_ReturnsNull()
+    {
+        var service = CreateService(null);
+
+        Assert.Null(service.Role);
+    }
+
+    [Fact]
+    public void IsAuthenticated_WithAuthenticatedIdentity_ReturnsTrue()
+    {
+        var principal = CreateAuthenticatedPrincipal(new Claim(ClaimTypes.Role, "Owner"));
+        var service = CreateService(principal);
+
+        Assert.True(service.IsAuthenticated);
+    }
+
+    [Fact]
+    public void IsAuthenticated_WithNoHttpContext_ReturnsFalse()
+    {
+        var service = CreateService(null);
+
+        Assert.False(service.IsAuthenticated);
+    }
+}

--- a/fencemark.Tests/DataIsolationTests.cs
+++ b/fencemark.Tests/DataIsolationTests.cs
@@ -19,6 +19,7 @@ public class DataIsolationTests
         public string? UserId { get; set; }
         public string? Email { get; set; }
         public string? OrganizationId { get; set; }
+        public string? Role { get; set; }
         public bool IsAuthenticated => !string.IsNullOrEmpty(UserId);
     }
 

--- a/fencemark.Tests/RlsPerformanceBenchmarks.cs
+++ b/fencemark.Tests/RlsPerformanceBenchmarks.cs
@@ -17,6 +17,7 @@ public class RlsPerformanceBenchmarks
         public string? UserId { get; set; }
         public string? Email { get; set; }
         public string? OrganizationId { get; set; }
+        public string? Role { get; set; }
         public bool IsAuthenticated => !string.IsNullOrEmpty(UserId);
     }
 


### PR DESCRIPTION
## Summary
Any authenticated organization member could perform destructive or admin-level operations — the `Role` enum (Owner/Admin/Member/Billing/ReadOnly) existed but was never checked at the endpoint level.

- Added a `Role` claim (standard `ClaimTypes.Role`) to the JWT principal in `OnTokenValidated`, sourced from the caller's `OrganizationMember` row, so ASP.NET Core's built-in role authorization works without extra config.
- Added `ICurrentUserService.Role` for endpoint/UI use.
- Added `AuthorizationPolicies.AdminOnly` (Owner or Admin role, plus `RequireAuthenticatedUser()` for defense-in-depth — see test plan) via a shared `AddFencemarkPolicies()` extension, registered once in `Program.cs`.
- Applied `AdminOnly` to:
  - `DeleteJob` (the example cited in the issue)
  - Delete endpoints for org-wide catalog/config entities: `Component`, `FenceType`, `GateType`, `TaxRegion`, `Discount`, `PricingConfig`
  - Organization management: `UpdateOrganization`, `InviteUser`, `UpdateMemberRole`, `RemoveMember`

**Scoping note:** left per-job working data endpoints (`FenceSegment`, `GatePosition`, `Drawing`, `Quote`, `Parcel`) and self-service `DeleteAccount` untouched — those are routine actions any Member performs while estimating a job, not admin operations. Happy to extend further if the intent was broader.

## Test plan
- [x] Added `AuthorizationPoliciesTests` — exercises the real `IAuthorizationService` wired up exactly as `Program.cs` configures it (not a mock): Owner/Admin succeed, Member/Billing/ReadOnly fail, no-role-claim fails, and an unauthenticated principal with a forged role claim fails (this last case caught a real gap — `RequireRole` alone doesn't imply authentication, fixed by adding `RequireAuthenticatedUser()`)
- [x] Added `CurrentUserServiceTests` for the new `Role` property
- [x] Updated `DataIsolationTests`/`RlsPerformanceBenchmarks` test doubles for the new `ICurrentUserService.Role` member
- [x] `dotnet build` succeeds for both `fencemark.ApiService` and `fencemark.Client`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 147 passed, 11 skipped (Docker/Aspire-only), 0 failed
- [ ] E2E (`AllEndpointsE2ETests`, `ComprehensiveJobFlowE2ETests`) not run — require a live AppHost/SQL Server not available in this environment. Should be safe since a self-onboarded test user is created as `Owner` (see `OrganizationService.CreateOrganizationAsync`), but worth a manual pass before merge.

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)