### PR TITLE
[High] Reject entity creation when user has no organization

### DIFF
--- a/fencemark.ApiService/Features/Components/ComponentEndpoints.cs
+++ b/fencemark.ApiService/Features/Components/ComponentEndpoints.cs
@@ -63,7 +63,7 @@ public static class ComponentEndpoints
         return component != null ? Results.Ok(component) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateComponent(
+    internal static async Task<IResult> CreateComponent(
         Component request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -72,7 +72,11 @@ public static class ComponentEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/Discounts/DiscountEndpoints.cs
+++ b/fencemark.ApiService/Features/Discounts/DiscountEndpoints.cs
@@ -65,7 +65,7 @@ public static class DiscountEndpoints
         return discount != null ? Results.Ok(discount) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateDiscount(
+    internal static async Task<IResult> CreateDiscount(
         DiscountRule request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -74,18 +74,22 @@ public static class DiscountEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
         // Validate promo code uniqueness if provided
         if (!string.IsNullOrEmpty(request.PromoCode))
         {
             var existingPromo = await db.DiscountRules
-                .AnyAsync(d => d.OrganizationId == currentUser.OrganizationId 
+                .AnyAsync(d => d.OrganizationId == organizationId
                     && d.PromoCode == request.PromoCode, ct);
-            
+
             if (existingPromo)
                 return Results.BadRequest(new { error = "Promo code already exists" });
         }
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/Drawings/DrawingEndpoints.cs
+++ b/fencemark.ApiService/Features/Drawings/DrawingEndpoints.cs
@@ -99,7 +99,7 @@ public static class DrawingEndpoints
         return drawing != null ? Results.Ok(drawing) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateDrawing(
+    internal static async Task<IResult> CreateDrawing(
         DrawingRequest request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -108,12 +108,16 @@ public static class DrawingEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
         // Verify job exists if provided
         if (!string.IsNullOrEmpty(request.JobId))
         {
             var job = await db.Jobs
-                .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == currentUser.OrganizationId, ct);
-            
+                .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == organizationId, ct);
+
             if (job == null)
                 return Results.BadRequest(new { error = "Job not found or access denied" });
         }
@@ -122,8 +126,8 @@ public static class DrawingEndpoints
         if (!string.IsNullOrEmpty(request.ParcelId))
         {
             var parcel = await db.Parcels
-                .FirstOrDefaultAsync(p => p.Id == request.ParcelId && p.OrganizationId == currentUser.OrganizationId, ct);
-            
+                .FirstOrDefaultAsync(p => p.Id == request.ParcelId && p.OrganizationId == organizationId, ct);
+
             if (parcel == null)
                 return Results.BadRequest(new { error = "Parcel not found or access denied" });
         }
@@ -131,7 +135,7 @@ public static class DrawingEndpoints
         var drawing = new Drawing
         {
             Id = Guid.NewGuid().ToString(),
-            OrganizationId = currentUser.OrganizationId ?? string.Empty,
+            OrganizationId = organizationId,
             JobId = request.JobId,
             ParcelId = request.ParcelId,
             Name = request.Name,

--- a/fencemark.ApiService/Features/FenceSegments/FenceSegmentEndpoints.cs
+++ b/fencemark.ApiService/Features/FenceSegments/FenceSegmentEndpoints.cs
@@ -107,7 +107,7 @@ public static class FenceSegmentEndpoints
         return segment != null ? Results.Ok(segment) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateFenceSegment(
+    internal static async Task<IResult> CreateFenceSegment(
         FenceSegmentRequest request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -116,10 +116,14 @@ public static class FenceSegmentEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
         // Verify job exists and belongs to the organization
         var job = await db.Jobs
-            .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == currentUser.OrganizationId, ct);
-        
+            .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == organizationId, ct);
+
         if (job == null)
             return Results.BadRequest(new { error = "Job not found or access denied" });
 
@@ -127,8 +131,8 @@ public static class FenceSegmentEndpoints
         if (!string.IsNullOrEmpty(request.ParcelId))
         {
             var parcel = await db.Parcels
-                .FirstOrDefaultAsync(p => p.Id == request.ParcelId && p.OrganizationId == currentUser.OrganizationId, ct);
-            
+                .FirstOrDefaultAsync(p => p.Id == request.ParcelId && p.OrganizationId == organizationId, ct);
+
             if (parcel == null)
                 return Results.BadRequest(new { error = "Parcel not found or access denied" });
         }
@@ -136,7 +140,7 @@ public static class FenceSegmentEndpoints
         var segment = new FenceSegment
         {
             Id = Guid.NewGuid().ToString(),
-            OrganizationId = currentUser.OrganizationId ?? string.Empty,
+            OrganizationId = organizationId,
             JobId = request.JobId,
             ParcelId = request.ParcelId,
             Name = request.Name,

--- a/fencemark.ApiService/Features/Fences/FenceEndpoints.cs
+++ b/fencemark.ApiService/Features/Fences/FenceEndpoints.cs
@@ -75,7 +75,7 @@ public static class FenceEndpoints
         return fence != null ? Results.Ok(fence) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateFence(
+    internal static async Task<IResult> CreateFence(
         FenceType request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -84,7 +84,11 @@ public static class FenceEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/GatePositions/GatePositionEndpoints.cs
+++ b/fencemark.ApiService/Features/GatePositions/GatePositionEndpoints.cs
@@ -85,7 +85,7 @@ public static class GatePositionEndpoints
         return position != null ? Results.Ok(position) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateGatePosition(
+    internal static async Task<IResult> CreateGatePosition(
         GatePositionRequest request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -94,17 +94,21 @@ public static class GatePositionEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
         // Verify fence segment exists and belongs to the organization
         var segment = await db.FenceSegments
-            .FirstOrDefaultAsync(f => f.Id == request.FenceSegmentId && f.OrganizationId == currentUser.OrganizationId, ct);
-        
+            .FirstOrDefaultAsync(f => f.Id == request.FenceSegmentId && f.OrganizationId == organizationId, ct);
+
         if (segment == null)
             return Results.BadRequest(new { error = "Fence segment not found or access denied" });
 
         var position = new GatePosition
         {
             Id = Guid.NewGuid().ToString(),
-            OrganizationId = currentUser.OrganizationId ?? string.Empty,
+            OrganizationId = organizationId,
             FenceSegmentId = request.FenceSegmentId,
             GateTypeId = request.GateTypeId,
             Name = request.Name,

--- a/fencemark.ApiService/Features/Gates/GateEndpoints.cs
+++ b/fencemark.ApiService/Features/Gates/GateEndpoints.cs
@@ -64,7 +64,7 @@ public static class GateEndpoints
         return gate != null ? Results.Ok(gate) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateGate(
+    internal static async Task<IResult> CreateGate(
         GateType request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -73,7 +73,11 @@ public static class GateEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
+++ b/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
@@ -66,7 +66,7 @@ public static class JobEndpoints
         return job != null ? Results.Ok(job) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateJob(
+    internal static async Task<IResult> CreateJob(
         Job request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -75,7 +75,11 @@ public static class JobEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/Parcels/ParcelEndpoints.cs
+++ b/fencemark.ApiService/Features/Parcels/ParcelEndpoints.cs
@@ -83,7 +83,7 @@ public static class ParcelEndpoints
         return parcel != null ? Results.Ok(parcel) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateParcel(
+    internal static async Task<IResult> CreateParcel(
         Parcel request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -92,14 +92,18 @@ public static class ParcelEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
         // Verify job exists and belongs to the organization
         var job = await db.Jobs
-            .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == currentUser.OrganizationId, ct);
-        
+            .FirstOrDefaultAsync(j => j.Id == request.JobId && j.OrganizationId == organizationId, ct);
+
         if (job == null)
             return Results.BadRequest(new { error = "Job not found or access denied" });
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;

--- a/fencemark.ApiService/Features/Pricing/PricingEndpoints.cs
+++ b/fencemark.ApiService/Features/Pricing/PricingEndpoints.cs
@@ -64,7 +64,7 @@ public static class PricingEndpoints
         return config != null ? Results.Ok(config) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreatePricingConfig(
+    internal static async Task<IResult> CreatePricingConfig(
         PricingConfig request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -73,7 +73,11 @@ public static class PricingEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;
@@ -82,7 +86,7 @@ public static class PricingEndpoints
         if (request.IsDefault)
         {
             var existingDefaults = await db.PricingConfigs
-                .Where(p => p.OrganizationId == currentUser.OrganizationId && p.IsDefault)
+                .Where(p => p.OrganizationId == organizationId && p.IsDefault)
                 .ToListAsync(ct);
             
             foreach (var existing in existingDefaults)

--- a/fencemark.ApiService/Features/TaxRegions/TaxRegionEndpoints.cs
+++ b/fencemark.ApiService/Features/TaxRegions/TaxRegionEndpoints.cs
@@ -62,7 +62,7 @@ public static class TaxRegionEndpoints
         return region != null ? Results.Ok(region) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateTaxRegion(
+    internal static async Task<IResult> CreateTaxRegion(
         TaxRegion request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
@@ -71,7 +71,11 @@ public static class TaxRegionEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
+        var organizationId = currentUser.OrganizationId;
+        if (string.IsNullOrEmpty(organizationId))
+            return Results.BadRequest(new { error = "User must belong to an organization" });
+
+        request.OrganizationId = organizationId;
         request.Id = Guid.NewGuid().ToString();
         request.CreatedAt = DateTime.UtcNow;
         request.UpdatedAt = DateTime.UtcNow;
@@ -80,7 +84,7 @@ public static class TaxRegionEndpoints
         if (request.IsDefault)
         {
             var existingDefaults = await db.TaxRegions
-                .Where(t => t.OrganizationId == currentUser.OrganizationId && t.IsDefault)
+                .Where(t => t.OrganizationId == organizationId && t.IsDefault)
                 .ToListAsync(ct);
             
             foreach (var existing in existingDefaults)

--- a/fencemark.ApiService/fencemark.ApiService.csproj
+++ b/fencemark.ApiService/fencemark.ApiService.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Allows fencemark.Tests to unit-test internal Minimal API endpoint handlers directly -->
+    <InternalsVisibleTo Include="fencemark.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />

--- a/fencemark.Tests/OrganizationIdGuardTests.cs
+++ b/fencemark.Tests/OrganizationIdGuardTests.cs
@@ -1,0 +1,202 @@
+using fencemark.ApiService.Data;
+using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Features.Components;
+using fencemark.ApiService.Features.Discounts;
+using fencemark.ApiService.Features.Drawings;
+using fencemark.ApiService.Features.Fences;
+using fencemark.ApiService.Features.FenceSegments;
+using fencemark.ApiService.Features.Gates;
+using fencemark.ApiService.Features.GatePositions;
+using fencemark.ApiService.Features.Jobs;
+using fencemark.ApiService.Features.Parcels;
+using fencemark.ApiService.Features.Pricing;
+using fencemark.ApiService.Features.TaxRegions;
+using fencemark.ApiService.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Regression tests for the "Missing Null Check for OrganizationId" issue: when an
+/// authenticated user has no organization membership, Create endpoints used to fall back
+/// to an empty-string OrganizationId (`currentUser.OrganizationId ?? string.Empty`),
+/// silently creating entities with no valid tenant and breaking RLS/data isolation.
+/// Every Create handler must now reject the request instead.
+/// </summary>
+public class OrganizationIdGuardTests
+{
+    private class NoOrgCurrentUserService : ICurrentUserService
+    {
+        public string? UserId => "user-1";
+        public string? Email => "user@test.com";
+        public string? OrganizationId => null;
+        public string? Role => null;
+        public bool IsAuthenticated => true;
+    }
+
+    private static ApplicationDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static void AssertBadRequest(IResult result)
+    {
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(400, statusResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateJob_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateJob()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new Job { Name = "Test Job", CustomerName = "Test Customer", OrganizationId = "ignored" };
+
+        var result = await JobEndpoints.CreateJob(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.Jobs);
+    }
+
+    [Fact]
+    public async Task CreateComponent_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateComponent()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new Component { Name = "Test Component", OrganizationId = "ignored", Category = "Post" };
+
+        var result = await ComponentEndpoints.CreateComponent(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.Components);
+    }
+
+    [Fact]
+    public async Task CreateFence_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateFenceType()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new FenceType { Name = "Test Fence", OrganizationId = "ignored" };
+
+        var result = await FenceEndpoints.CreateFence(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.FenceTypes);
+    }
+
+    [Fact]
+    public async Task CreateGate_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateGateType()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new GateType { Name = "Test Gate", OrganizationId = "ignored" };
+
+        var result = await GateEndpoints.CreateGate(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.GateTypes);
+    }
+
+    [Fact]
+    public async Task CreateTaxRegion_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateTaxRegion()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new TaxRegion { Name = "Test Region", OrganizationId = "ignored" };
+
+        var result = await TaxRegionEndpoints.CreateTaxRegion(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.TaxRegions);
+    }
+
+    [Fact]
+    public async Task CreateDiscount_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateDiscount()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new DiscountRule { Name = "Test Discount", OrganizationId = "ignored" };
+
+        var result = await DiscountEndpoints.CreateDiscount(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.DiscountRules);
+    }
+
+    [Fact]
+    public async Task CreatePricingConfig_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateConfig()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new PricingConfig { Name = "Test Config", OrganizationId = "ignored" };
+
+        var result = await PricingEndpoints.CreatePricingConfig(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.PricingConfigs);
+    }
+
+    [Fact]
+    public async Task CreateParcel_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateParcel()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new Parcel { Name = "Test Parcel", OrganizationId = "ignored", JobId = "some-job" };
+
+        var result = await ParcelEndpoints.CreateParcel(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.Parcels);
+    }
+
+    [Fact]
+    public async Task CreateDrawing_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateDrawing()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new DrawingEndpoints.DrawingRequest(
+            JobId: null, ParcelId: null, Name: "Test Drawing", Description: null,
+            DrawingType: null, FileName: "test.pdf", FilePath: "/tmp/test.pdf", MimeType: null, FileSize: 100);
+
+        var result = await DrawingEndpoints.CreateDrawing(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.Drawings);
+    }
+
+    [Fact]
+    public async Task CreateFenceSegment_WithNoOrganization_ReturnsBadRequestAndDoesNotCreateSegment()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new FenceSegmentEndpoints.FenceSegmentRequest(
+            JobId: "some-job", ParcelId: null, Name: "Test Segment", FenceTypeId: "some-fence-type",
+            GeoJsonGeometry: "{}", LengthInMetres: 10, IsSnappedToBoundary: false, Notes: null, IsVerifiedOnsite: false, OnsiteVerifiedLengthInMetres: null);
+
+        var result = await FenceSegmentEndpoints.CreateFenceSegment(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.FenceSegments);
+    }
+
+    [Fact]
+    public async Task CreateGatePosition_WithNoOrganization_ReturnsBadRequestAndDoesNotCreatePosition()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new NoOrgCurrentUserService();
+        var request = new GatePositionEndpoints.GatePositionRequest(
+            FenceSegmentId: "some-segment", GateTypeId: null, Name: "Test Gate Position",
+            GeoJsonLocation: "{}", PositionAlongSegment: 0.5m, Notes: null, IsVerifiedOnsite: false);
+
+        var result = await GatePositionEndpoints.CreateGatePosition(request, db, currentUser, CancellationToken.None);
+
+        AssertBadRequest(result);
+        Assert.Empty(db.GatePositions);
+    }
+}


### PR DESCRIPTION
## Summary
11 Create endpoints fell back to `currentUser.OrganizationId ?? string.Empty` when the caller had no organization membership, silently creating entities with an empty `OrganizationId` — breaking multi-tenant data isolation and RLS.

Fixed in: `JobEndpoints`, `ComponentEndpoints`, `FenceEndpoints`, `GateEndpoints`, `TaxRegionEndpoints`, `DiscountEndpoints`, `PricingEndpoints`, `ParcelEndpoints`, `DrawingEndpoints`, `FenceSegmentEndpoints`, `GatePositionEndpoints`. Each now returns `400 Bad Request` ("User must belong to an organization") instead of persisting orphaned data, and the guard runs before any other request validation in that handler.

**Testability change:** the 11 `Create*` handlers were changed from `private static` to `internal static`, with `<InternalsVisibleTo Include="fencemark.Tests" />` added to `fencemark.ApiService.csproj`. This lets the fix be verified directly against an in-memory `DbContext` without standing up a full HTTP pipeline — consistent with how the rest of the suite already unit-tests service/data logic.

## Test plan
- [x] Added `OrganizationIdGuardTests` — one test per affected Create handler, asserting a 400 response and that nothing is added to the corresponding `DbSet` when `ICurrentUserService.OrganizationId` is null
- [x] `dotnet build` succeeds for both `fencemark.ApiService` and `fencemark.Client`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 146 passed, 11 skipped (Docker/Aspire-only), 0 failed

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)