### PR TITLE
[High] Bind a dedicated DTO for Job create/update instead of the domain model

### DIFF
--- a/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
+++ b/fencemark.ApiService/Features/Jobs/JobEndpoints.cs
@@ -66,8 +66,8 @@ public static class JobEndpoints
         return job != null ? Results.Ok(job) : Results.NotFound();
     }
 
-    private static async Task<IResult> CreateJob(
-        Job request,
+    internal static async Task<IResult> CreateJob(
+        JobRequest request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
         CancellationToken ct)
@@ -75,19 +75,35 @@ public static class JobEndpoints
         if (!currentUser.IsAuthenticated)
             return Results.Unauthorized();
 
-        request.OrganizationId = currentUser.OrganizationId ?? string.Empty;
-        request.Id = Guid.NewGuid().ToString();
-        request.CreatedAt = DateTime.UtcNow;
-        request.UpdatedAt = DateTime.UtcNow;
+        var job = new Job
+        {
+            Id = Guid.NewGuid().ToString(),
+            OrganizationId = currentUser.OrganizationId ?? string.Empty,
+            Name = request.Name,
+            CustomerName = request.CustomerName,
+            CustomerEmail = request.CustomerEmail,
+            CustomerPhone = request.CustomerPhone,
+            InstallationAddress = request.InstallationAddress,
+            Status = request.Status,
+            TotalLinearMetres = request.TotalLinearMetres,
+            LaborCost = request.LaborCost,
+            MaterialsCost = request.MaterialsCost,
+            TotalCost = request.TotalCost,
+            Notes = request.Notes,
+            EstimatedStartDate = request.EstimatedStartDate,
+            EstimatedCompletionDate = request.EstimatedCompletionDate,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
 
-        db.Jobs.Add(request);
+        db.Jobs.Add(job);
         await db.SaveChangesAsync(ct);
-        return Results.Created($"/api/jobs/{request.Id}", request);
+        return Results.Created($"/api/jobs/{job.Id}", job);
     }
 
-    private static async Task<IResult> UpdateJob(
+    internal static async Task<IResult> UpdateJob(
         string id,
-        Job request,
+        JobRequest request,
         ApplicationDbContext db,
         ICurrentUserService currentUser,
         CancellationToken ct)
@@ -135,4 +151,26 @@ public static class JobEndpoints
         await db.SaveChangesAsync(ct);
         return Results.Ok(new { success = true });
     }
+
+    /// <summary>
+    /// API contract for creating/updating a job. Deliberately excludes Id, OrganizationId,
+    /// CreatedAt, and navigation properties (Organization, LineItems) - those are either
+    /// server-controlled or would let a client mass-assign unrelated records via EF Core's
+    /// navigation-property binding if the Job domain model were bound directly.
+    /// </summary>
+    public record JobRequest(
+        string Name,
+        string CustomerName,
+        string? CustomerEmail,
+        string? CustomerPhone,
+        string? InstallationAddress,
+        JobStatus Status = JobStatus.Draft,
+        decimal TotalLinearMetres = 0,
+        decimal LaborCost = 0,
+        decimal MaterialsCost = 0,
+        decimal TotalCost = 0,
+        string? Notes = null,
+        DateTime? EstimatedStartDate = null,
+        DateTime? EstimatedCompletionDate = null
+    );
 }

--- a/fencemark.ApiService/fencemark.ApiService.csproj
+++ b/fencemark.ApiService/fencemark.ApiService.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Allows fencemark.Tests to unit-test internal Minimal API endpoint handlers directly -->
+    <InternalsVisibleTo Include="fencemark.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />

--- a/fencemark.Tests/JobEndpointsTests.cs
+++ b/fencemark.Tests/JobEndpointsTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using fencemark.ApiService.Data;
+using fencemark.ApiService.Data.Models;
+using fencemark.ApiService.Features.Jobs;
+using fencemark.ApiService.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Regression tests for the "Domain Model Used as API Contract" over-posting issue:
+/// JobEndpoints used to bind the Job domain model directly from the request body, so a
+/// client could set Id, OrganizationId, CreatedAt (or inject data via the Organization/
+/// LineItems navigation properties) in the JSON payload. CreateJob/UpdateJob now bind a
+/// dedicated JobRequest DTO that only exposes the fields the UI actually edits.
+/// </summary>
+public class JobEndpointsTests
+{
+    private class TestCurrentUserService : ICurrentUserService
+    {
+        public string? UserId { get; set; } = "user-1";
+        public string? Email { get; set; } = "user@test.com";
+        public string? OrganizationId { get; set; }
+        public string? Role { get; set; }
+        public bool IsAuthenticated => !string.IsNullOrEmpty(UserId);
+    }
+
+    private static ApplicationDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task CreateJob_OverPostedIdOrganizationIdAndCreatedAt_AreIgnored()
+    {
+        // Simulate a malicious/buggy client posting fields that are not part of the JobRequest
+        // contract. System.Text.Json silently ignores unknown properties by default, which is
+        // exactly the behavior we're relying on to close the over-posting hole.
+        var maliciousJson = """
+        {
+            "id": "attacker-controlled-id",
+            "organizationId": "someone-elses-org",
+            "createdAt": "2000-01-01T00:00:00Z",
+            "name": "Test Job",
+            "customerName": "Test Customer"
+        }
+        """;
+
+        var request = JsonSerializer.Deserialize<JobEndpoints.JobRequest>(
+            maliciousJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        await using var db = CreateDbContext();
+        var currentUser = new TestCurrentUserService { OrganizationId = "real-org-id" };
+        var before = DateTime.UtcNow;
+
+        var result = await JobEndpoints.CreateJob(request, db, currentUser, CancellationToken.None);
+
+        Assert.Equal(201, Assert.IsAssignableFrom<IStatusCodeHttpResult>(result).StatusCode);
+        var createdJob = Assert.Single(db.Jobs);
+        Assert.NotEqual("attacker-controlled-id", createdJob.Id);
+        Assert.Equal("real-org-id", createdJob.OrganizationId);
+        Assert.True(createdJob.CreatedAt >= before, "CreatedAt should be server-generated, not the client-supplied value.");
+        Assert.Equal("Test Job", createdJob.Name);
+        Assert.Equal("Test Customer", createdJob.CustomerName);
+    }
+
+    [Fact]
+    public async Task CreateJob_WithValidRequest_CreatesJobScopedToCallerOrganization()
+    {
+        await using var db = CreateDbContext();
+        var currentUser = new TestCurrentUserService { OrganizationId = "org-1" };
+        var request = new JobEndpoints.JobRequest(
+            Name: "Backyard Fence",
+            CustomerName: "Jane Doe",
+            CustomerEmail: "jane@example.com",
+            CustomerPhone: null,
+            InstallationAddress: "1 Test St");
+
+        var result = await JobEndpoints.CreateJob(request, db, currentUser, CancellationToken.None);
+
+        Assert.Equal(201, Assert.IsAssignableFrom<IStatusCodeHttpResult>(result).StatusCode);
+        var createdJob = Assert.Single(db.Jobs);
+        Assert.Equal("org-1", createdJob.OrganizationId);
+        Assert.False(string.IsNullOrEmpty(createdJob.Id));
+        Assert.Equal(JobStatus.Draft, createdJob.Status);
+    }
+
+    [Fact]
+    public async Task UpdateJob_DoesNotAllowChangingOrganizationId()
+    {
+        await using var db = CreateDbContext();
+        var job = new Job
+        {
+            Id = "job-1",
+            Name = "Original",
+            CustomerName = "Original Customer",
+            OrganizationId = "org-1",
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        db.Jobs.Add(job);
+        await db.SaveChangesAsync();
+
+        var currentUser = new TestCurrentUserService { OrganizationId = "org-1" };
+        // JobRequest has no OrganizationId member at all, so there is no way for the
+        // request body to influence tenant assignment on update.
+        var request = new JobEndpoints.JobRequest(
+            Name: "Updated Name",
+            CustomerName: "Updated Customer",
+            CustomerEmail: null,
+            CustomerPhone: null,
+            InstallationAddress: null);
+
+        var result = await JobEndpoints.UpdateJob("job-1", request, db, currentUser, CancellationToken.None);
+
+        Assert.Equal(200, Assert.IsAssignableFrom<IStatusCodeHttpResult>(result).StatusCode);
+        var updatedJob = await db.Jobs.SingleAsync(j => j.Id == "job-1");
+        Assert.Equal("org-1", updatedJob.OrganizationId);
+        Assert.Equal("Updated Name", updatedJob.Name);
+        Assert.Equal("Updated Customer", updatedJob.CustomerName);
+    }
+}


### PR DESCRIPTION
## Summary
`CreateJob`/`UpdateJob` bound the `Job` domain model directly from the HTTP request body. The three scalar over-posting fields called out in the issue (`Id`, `OrganizationId`, `CreatedAt`) turned out to already be overwritten server-side after binding on `CreateJob`, and `UpdateJob` already copied fields onto the tracked entity one-by-one rather than replacing it — so those three specifically weren't exploitable today.

However, binding the domain model also exposes its `Organization` and `LineItems` navigation properties to the request body with **no server-side override**. A client POSTing a body containing `"organization": {...}` or `"lineItems": [...]` would have those objects bound onto the tracked `Job`, and EF Core's change tracker would attempt to insert/associate them — a real, currently-latent mass-assignment vector.

Fix: added `JobEndpoints.JobRequest`, a record exposing only the fields the Jobs UI (`Jobs.razor`) actually edits (no `Id`, `OrganizationId`, `CreatedAt`, or navigation properties — structurally impossible to bind since the record doesn't declare them). `CreateJob` now constructs a new `Job` from it; `UpdateJob` copies the same allow-listed fields it always did, just sourced from the narrower DTO. No client-side changes needed — `JobDto` sends a superset of fields and the extras are silently ignored by `System.Text.Json`, matching current wire behavior.

**Testability:** `CreateJob`/`UpdateJob` changed from `private` to `internal` (`InternalsVisibleTo` added to `fencemark.ApiService.csproj`) so the fix can be verified directly against an in-memory `DbContext`.

## Test plan
- [x] Added `JobEndpointsTests`:
  - `CreateJob_OverPostedIdOrganizationIdAndCreatedAt_AreIgnored` — deserializes a malicious JSON payload containing `id`/`organizationId`/`createdAt` into `JobRequest` and confirms the persisted job ignores all three
  - `CreateJob_WithValidRequest_CreatesJobScopedToCallerOrganization` — happy path
  - `UpdateJob_DoesNotAllowChangingOrganizationId` — confirms tenant reassignment is structurally impossible via the update DTO
- [x] `dotnet build` succeeds for both `fencemark.ApiService` and `fencemark.Client`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 138 passed, 11 skipped (Docker/Aspire-only), 0 failed

**Note:** this PR branches from `main`, independent of the other open security-fix PRs (#192-195) touching `fencemark.ApiService.csproj`'s `InternalsVisibleTo` entry and `JobEndpoints.cs`. Expect a small, easy merge conflict with #108 depending on merge order.

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)