### PR TITLE
[High] Log onboarding check failures instead of swallowing them

### DIFF
--- a/fencemark.Client/Components/Layout/MainLayout.razor
+++ b/fencemark.Client/Components/Layout/MainLayout.razor
@@ -5,6 +5,7 @@
 @inject IDialogService DialogService
 @inject NavigationManager NavigationManager
 @inject IConfiguration Configuration
+@inject ILogger<MainLayout> Logger
 
 <AuthorizeView>
     <Authorized>
@@ -177,9 +178,9 @@
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Silently fail onboarding check
+            Logger.LogWarning(ex, "Onboarding status check failed");
         }
     }
 

--- a/fencemark.Tests/MainLayoutOnboardingTests.cs
+++ b/fencemark.Tests/MainLayoutOnboardingTests.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using System.Security.Claims;
+using fencemark.Client.Components.Layout;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Regression test for the "Empty Catch Block Swallows All Errors" issue:
+/// MainLayout.CheckOnboardingStatus used to have a bare `catch { }` that silently
+/// discarded any exception during the onboarding check. It must now log the failure.
+///
+/// This invokes the private CheckOnboardingStatus method directly via reflection rather
+/// than through bUnit/full component rendering (not set up in this repo), which is safe
+/// here because the induced failure (AuthenticationStateProvider throwing) happens before
+/// the method ever touches rendering-dependent members like StateHasChanged().
+/// </summary>
+public class MainLayoutOnboardingTests
+{
+    private class ThrowingAuthenticationStateProvider : AuthenticationStateProvider
+    {
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            => throw new InvalidOperationException("Simulated failure fetching authentication state");
+    }
+
+    private class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, exception));
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    private static void SetInjectedProperty(object target, string propertyName, object value)
+    {
+        var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Expected an injected '{propertyName}' property on {target.GetType()}.");
+        property.SetValue(target, value);
+    }
+
+    [Fact]
+    public async Task CheckOnboardingStatus_WhenAuthStateThrows_LogsWarningInsteadOfSwallowingIt()
+    {
+        var layout = new MainLayout();
+        var logger = new CapturingLogger<MainLayout>();
+
+        SetInjectedProperty(layout, "AuthenticationStateProvider", new ThrowingAuthenticationStateProvider());
+        SetInjectedProperty(layout, "Logger", logger);
+
+        var method = typeof(MainLayout).GetMethod("CheckOnboardingStatus", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("CheckOnboardingStatus method not found - has MainLayout.razor been renamed/refactored?");
+
+        // Should not throw - the exception must be caught, not propagated.
+        var task = (Task)method.Invoke(layout, null)!;
+        await task;
+
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Exception is InvalidOperationException);
+    }
+}

--- a/fencemark.Tests/fencemark.Tests.csproj
+++ b/fencemark.Tests/fencemark.Tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <ProjectReference Include="..\fencemark.AppHost\fencemark.AppHost.csproj" />
     <ProjectReference Include="..\fencemark.ApiService\fencemark.ApiService.csproj" />
+    <ProjectReference Include="..\fencemark.Client\fencemark.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
`MainLayout.CheckOnboardingStatus` had a bare `catch { }` that silently discarded every exception during the onboarding check (auth state lookup, `/api/auth/me` call, navigation). This made production failures in that flow undiagnosable - a user could get stuck without onboarding redirecting correctly and there'd be zero trace of why.

- Injected `ILogger<MainLayout>` (matching the pattern already used in `OrganizationSettings.razor`)
- Changed `catch { }` to `catch (Exception ex) { Logger.LogWarning(ex, "Onboarding status check failed"); }` — a warning rather than an error, since transient/expected failures (e.g. brief unauthenticated state during page load) shouldn't be treated as incidents

## Test plan
- [x] Added `MainLayoutOnboardingTests.CheckOnboardingStatus_WhenAuthStateThrows_LogsWarningInsteadOfSwallowingIt` — invokes the private `CheckOnboardingStatus` method directly (via reflection) with a fake `AuthenticationStateProvider` that throws, and asserts the exception is logged as a `Warning` rather than propagating or vanishing. There's no bUnit setup in this repo for full component rendering, so this is a targeted white-box test rather than a rendered-component test; it's safe because the induced failure happens before the method touches any rendering-dependent members (`StateHasChanged()`).
- [x] Added a `fencemark.Tests` → `fencemark.Client` project reference (previously missing) to make this and future Blazor logic testable
- [x] `dotnet build` succeeds for `fencemark.Client` and `fencemark.Tests`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 136 passed, 11 skipped (Docker/Aspire-only), 0 failed

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)