### PR TITLE
[High] Guard against secrets in wwwroot appsettings, correct stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ WASM client connects to API at `https://localhost:62010` (or Aspire-assigned por
 
 ### Key Configuration Files
 
-- `fencemark.Client/wwwroot/appsettings.json` - WASM client config (gitignored, created at build)
+- `fencemark.Client/wwwroot/appsettings*.json` - WASM client config, checked into source control per-environment (`.Development`, `.Staging`, `.dev`, `.prod`) and overwritten at deploy time by the GitHub Actions workflows. Only public OAuth client/tenant IDs and URLs belong here - the WASM bundle is delivered to every browser, so nothing in these files can ever be a real secret. `appsettings.template.json` documents the expected shape for a new environment.
 - `fencemark.ApiService/appsettings.json` - API config including AzureAd settings
 - `fencemark.AppHost/nginx.conf` - nginx config for local WASM serving
 

--- a/fencemark.Tests/WwwrootAppSettingsSecurityTests.cs
+++ b/fencemark.Tests/WwwrootAppSettingsSecurityTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Regression tests for "Sensitive Configuration in wwwroot appsettings" (#111).
+///
+/// The Blazor WASM bundle (including everything under wwwroot) is delivered to every
+/// browser, so nothing checked into fencemark.Client/wwwroot/appsettings*.json can ever
+/// be a real secret - the Azure AD tenant/client IDs and API URLs already there are
+/// public identifiers by design, visible to anyone via a browser's network tab regardless
+/// of git history. This test guards against someone accidentally introducing an actual
+/// secret (API key, connection string, client secret) into one of these files in future.
+/// </summary>
+public class WwwrootAppSettingsSecurityTests
+{
+    private static readonly string[] ForbiddenKeyFragments =
+    [
+        "clientsecret",
+        "apikey",
+        "api_key",
+        "password",
+        "connectionstring",
+        "privatekey",
+        "secretkey",
+        "accesskey",
+        "subscriptionkey"
+    ];
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "fencemark.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                $"Could not locate repository root (fencemark.slnx) walking up from {AppContext.BaseDirectory}");
+    }
+
+    private static string[] GetWwwrootAppSettingsFiles()
+    {
+        var wwwrootPath = Path.Combine(FindRepoRoot(), "fencemark.Client", "wwwroot");
+        return Directory.GetFiles(wwwrootPath, "appsettings*.json");
+    }
+
+    [Fact]
+    public void WwwrootAppSettingsFiles_CanBeLocated()
+    {
+        // Sanity check that the path-walking logic above actually finds the files -
+        // if this starts failing, the other test in this file is silently vacuous.
+        var files = GetWwwrootAppSettingsFiles();
+
+        Assert.NotEmpty(files);
+    }
+
+    [Fact]
+    public void WwwrootAppSettingsFiles_ContainNoSecretLikeKeys()
+    {
+        foreach (var file in GetWwwrootAppSettingsFiles())
+        {
+            var content = File.ReadAllText(file).ToLowerInvariant();
+
+            foreach (var forbidden in ForbiddenKeyFragments)
+            {
+                Assert.DoesNotContain(forbidden, content);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Investigated the claim in the issue and in `CLAUDE.md` that `fencemark.Client/wwwroot/appsettings.json` is gitignored — it isn't. `appsettings.json`, `.Development.json`, `.Staging.json`, `.dev.json`, and `.prod.json` are all tracked in git and contain per-environment Azure AD tenant/client IDs and API URLs.

**On the actual risk:** these values aren't exploitable secrets. The Blazor WASM bundle (everything under `wwwroot`) ships to every browser, so a tenant ID or public OAuth client ID baked into it is visible via the network tab regardless of git history — this is inherent to SPA architecture, not a bug. `deploy-environment.yml`/`deploy-static-web-app.yml` already overwrite these files at deploy time with the real values for that environment.

**What I did:**
- Corrected the `CLAUDE.md` line that inaccurately claimed the file was gitignored, to describe what actually happens (checked in, deploy-time overwritten, template file documents the shape for new environments)
- Added `WwwrootAppSettingsSecurityTests`, which scans every `wwwroot/appsettings*.json` for secret-shaped keys (`ClientSecret`, `ApiKey`, `ConnectionString`, `Password`, `PrivateKey`, etc.) and fails the build if one ever shows up there — this is the durable, CI-enforced version of "verify nothing sensitive lands in this file"

**What I deliberately did not do:** change git tracking or add these files to `.gitignore`. There's no local-dev generation step for `wwwroot/appsettings.json` today (confirmed by searching `fencemark.AppHost` and `infra/scripts` — nothing creates it), so untracking it would break `dotnet run --project fencemark.AppHost` for every developer with no replacement in place. If you want to pursue that properly, it needs a local setup script first — happy to scope that separately.

## Test plan
- [x] Added `WwwrootAppSettingsSecurityTests` (2 tests): confirms the files can be located from the repo root, and that none contain secret-shaped keys
- [x] Verified the guard actually fires: temporarily wrote a `ClientSecret` key into `appsettings.json`, confirmed the test failed, reverted (`git status` confirms the file is back to its original committed state)
- [x] `dotnet build` succeeds for `fencemark.ApiService` and `fencemark.Client`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 137 passed, 11 skipped (Docker/Aspire-only), 0 failed

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)