### PR TITLE
Implement real NSW and VIC cadastral parcel lookups

### DIFF
--- a/fencemark.ApiService/Services/CadastralService.cs
+++ b/fencemark.ApiService/Services/CadastralService.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 
 namespace fencemark.ApiService.Services;
@@ -85,12 +87,10 @@ public class StateConfig
 /// <summary>
 /// Implementation of cadastral service that queries Australian state cadastral APIs
 /// </summary>
-#pragma warning disable CS9113 // Parameter is unread - httpClientFactory reserved for API implementation
 public class CadastralService(
     IHttpClientFactory httpClientFactory,
     ILogger<CadastralService> logger,
     IOptions<CadastralOptions> options) : ICadastralService
-#pragma warning restore CS9113
 {
     private readonly CadastralOptions _options = options.Value;
 
@@ -207,20 +207,166 @@ public class CadastralService(
 
         try
         {
-            // TODO: Implement actual API calls for each state
-            // Each state has different API formats (ArcGIS REST, WFS, etc.)
-            logger.LogInformation(
-                "Would query {State} cadastral API at {Endpoint} for coordinates ({Lat}, {Lng})",
-                state, stateConfig.Endpoint, latitude, longitude);
-
-            // Placeholder - return null until real implementations are added
-            return null;
+            return state.ToUpperInvariant() switch
+            {
+                "NSW" => await GetNswParcelAsync(latitude, longitude, stateConfig.Endpoint, cancellationToken),
+                "VIC" => await GetVicParcelAsync(latitude, longitude, stateConfig.Endpoint, cancellationToken),
+                _ => LogUnimplementedState(state)
+            };
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error querying cadastral API for state {State}", state);
             return null;
         }
+    }
+
+    private CadastralParcelResult? LogUnimplementedState(string state)
+    {
+        logger.LogInformation("Cadastral API integration not yet implemented for state {State}", state);
+        return null;
+    }
+
+    /// <summary>
+    /// Queries the NSW_Cadastre "Lot" layer (id 9) on the NSW Spatial Services ArcGIS
+    /// MapServer for the parcel intersecting the given point.
+    /// See https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Cadastre/MapServer/9
+    /// </summary>
+    private Task<CadastralParcelResult?> GetNswParcelAsync(
+        double latitude,
+        double longitude,
+        string endpoint,
+        CancellationToken cancellationToken)
+        => QueryArcGisParcelAsync(
+            endpoint,
+            "NSW",
+            latitude,
+            longitude,
+            parcelIdField: "lotidstring",
+            fallbackIdField: "planlabel",
+            areaField: "shape_Area",
+            cancellationToken);
+
+    /// <summary>
+    /// Queries the Vicmap_Parcel "Parcel Map Polygons" layer (id 0) on the Victorian
+    /// Government's ArcGIS FeatureServer for the parcel intersecting the given point.
+    /// See https://services-ap1.arcgis.com/P744lA0wf4LlBZ84/ArcGIS/rest/services/Vicmap_Parcel/FeatureServer/0
+    /// </summary>
+    private Task<CadastralParcelResult?> GetVicParcelAsync(
+        double latitude,
+        double longitude,
+        string endpoint,
+        CancellationToken cancellationToken)
+        => QueryArcGisParcelAsync(
+            endpoint,
+            "VIC",
+            latitude,
+            longitude,
+            parcelIdField: "parcel_spi",
+            fallbackIdField: "parcel_plan_number",
+            areaField: "Shape__Area",
+            cancellationToken);
+
+    /// <summary>
+    /// Performs an ArcGIS REST "query" spatial intersection lookup for a point and returns
+    /// the first matching parcel as GeoJSON. Both NSW and VIC cadastral services expose this
+    /// same ArcGIS REST query API shape (just with different field names per state), so the
+    /// query/parsing logic is shared.
+    /// </summary>
+    private async Task<CadastralParcelResult?> QueryArcGisParcelAsync(
+        string endpoint,
+        string state,
+        double latitude,
+        double longitude,
+        string parcelIdField,
+        string fallbackIdField,
+        string areaField,
+        CancellationToken cancellationToken)
+    {
+        var queryUrl =
+            $"{endpoint.TrimEnd('/')}/query" +
+            $"?geometry={longitude.ToString(CultureInfo.InvariantCulture)},{latitude.ToString(CultureInfo.InvariantCulture)}" +
+            "&geometryType=esriGeometryPoint" +
+            "&inSR=4326" +
+            "&spatialRel=esriSpatialRelIntersects" +
+            "&outFields=*" +
+            "&returnGeometry=true" +
+            "&outSR=4326" +
+            "&f=geojson";
+
+        var client = httpClientFactory.CreateClient();
+        using var response = await client.GetAsync(queryUrl, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning(
+                "Cadastral API for {State} returned {StatusCode} for coordinates ({Lat}, {Lng})",
+                state, response.StatusCode, latitude, longitude);
+            return null;
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        return ParseArcGisParcelResponse(body, state, parcelIdField, fallbackIdField, areaField);
+    }
+
+    /// <summary>
+    /// Parses an ArcGIS REST GeoJSON query response into a <see cref="CadastralParcelResult"/>.
+    /// Internal (rather than private) so it can be unit tested directly against canned
+    /// responses without requiring a live HTTP call.
+    /// </summary>
+    internal static CadastralParcelResult? ParseArcGisParcelResponse(
+        string geoJsonResponseBody,
+        string state,
+        string parcelIdField,
+        string fallbackIdField,
+        string areaField)
+    {
+        using var document = JsonDocument.Parse(geoJsonResponseBody);
+
+        if (!document.RootElement.TryGetProperty("features", out var features) ||
+            features.ValueKind != JsonValueKind.Array ||
+            features.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        var firstFeature = features[0];
+        if (!firstFeature.TryGetProperty("properties", out var properties))
+        {
+            return null;
+        }
+
+        var parcelId = GetStringOrNull(properties, parcelIdField) ?? GetStringOrNull(properties, fallbackIdField);
+        var areaSquareMetres = GetDoubleOrNull(properties, areaField);
+
+        return new CadastralParcelResult(
+            State: state,
+            ParcelId: parcelId,
+            Address: null,
+            GeoJson: geoJsonResponseBody,
+            AreaSquareMetres: areaSquareMetres,
+            LastUpdated: DateTime.UtcNow);
+    }
+
+    private static string? GetStringOrNull(JsonElement properties, string fieldName)
+    {
+        if (!properties.TryGetProperty(fieldName, out var value) ||
+            value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : value.GetRawText();
+    }
+
+    private static double? GetDoubleOrNull(JsonElement properties, string fieldName)
+    {
+        if (!properties.TryGetProperty(fieldName, out var value) || value.ValueKind != JsonValueKind.Number)
+        {
+            return null;
+        }
+
+        return value.GetDouble();
     }
 
     private StateConfig? GetStateConfig(string state)

--- a/fencemark.ApiService/appsettings.json
+++ b/fencemark.ApiService/appsettings.json
@@ -29,7 +29,7 @@
       "Enabled": true
     },
     "VIC": {
-      "Endpoint": "https://services.land.vic.gov.au/catalogue/publicproxy/guest/dv_geoserver/wfs",
+      "Endpoint": "https://services-ap1.arcgis.com/P744lA0wf4LlBZ84/ArcGIS/rest/services/Vicmap_Parcel/FeatureServer/0",
       "Enabled": true
     },
     "QLD": {

--- a/fencemark.ApiService/fencemark.ApiService.csproj
+++ b/fencemark.ApiService/fencemark.ApiService.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Allows fencemark.Tests to unit-test internal implementation details directly -->
+    <InternalsVisibleTo Include="fencemark.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />

--- a/fencemark.Tests/CadastralServiceTests.cs
+++ b/fencemark.Tests/CadastralServiceTests.cs
@@ -1,0 +1,283 @@
+using System.Net;
+using System.Text;
+using fencemark.ApiService.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace fencemark.Tests;
+
+/// <summary>
+/// Tests for the real NSW/VIC ArcGIS REST cadastral integration added for issue #182
+/// (child of #174). Sample JSON below is captured from live queries against the actual
+/// NSW_Cadastre (Lot layer 9) and Vicmap_Parcel (layer 0) ArcGIS REST services for the
+/// coordinates named in the issue (Sydney / Melbourne CBD), so the parsing tests exercise
+/// real field names and shapes rather than an invented schema.
+/// </summary>
+public class CadastralServiceTests
+{
+    private const string NswSampleResponse = """
+        {"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"EPSG:4326"}},"features":[{"type":"Feature","id":1236669,"geometry":{"type":"Polygon","coordinates":[[[151.2095,-33.8678],[151.2088,-33.8684],[151.2095,-33.8678]]]},"properties":{"objectid":1236669,"cadid":102169538,"planoid":47274,"plannumber":598704,"planlabel":"DP598704","lotnumber":"1","planlotarea":null,"lotidstring":"1//DP598704","urbanity":"U","shape_Length":488.14303267080732,"shape_Area":10328.589025760246}}]}
+        """;
+
+    private const string VicSampleResponse = """
+        {"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"EPSG:4326"}},"features":[{"type":"Feature","id":2068618,"geometry":{"type":"Polygon","coordinates":[[[144.9637,-37.8139],[144.9633,-37.8141],[144.9637,-37.8139]]]},"properties":{"OBJECTID":2068618,"parcel_ufi":872303044,"parcel_pfi":"152191430","parcel_spi":"PC366537","parcel_plan_number":"PC366537","parcel_status":"A","Shape__Area":6193.015625,"Shape__Length":345.89735383088475}}]}
+        """;
+
+    private const string EmptyFeatureCollectionResponse = """{"type":"FeatureCollection","features":[]}""";
+
+    private class CapturingHttpMessageHandler(HttpStatusCode statusCode, string responseBody) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private class SingleClientHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler);
+    }
+
+    private static CadastralService CreateService(HttpMessageHandler handler, CadastralOptions options)
+    {
+        return new CadastralService(
+            new SingleClientHttpClientFactory(handler),
+            new Logger<CadastralService>(new LoggerFactory()),
+            Options.Create(options));
+    }
+
+    // --- ParseArcGisParcelResponse (pure parsing logic) ---
+
+    [Fact]
+    public void ParseArcGisParcelResponse_WithRealNswResponse_ExtractsLotIdAndArea()
+    {
+        var result = CadastralService.ParseArcGisParcelResponse(
+            NswSampleResponse, "NSW", parcelIdField: "lotidstring", fallbackIdField: "planlabel", areaField: "shape_Area");
+
+        Assert.NotNull(result);
+        Assert.Equal("NSW", result!.State);
+        Assert.Equal("1//DP598704", result.ParcelId);
+        Assert.Equal(10328.589025760246, result.AreaSquareMetres);
+        Assert.Equal(NswSampleResponse, result.GeoJson);
+    }
+
+    [Fact]
+    public void ParseArcGisParcelResponse_WithRealVicResponse_ExtractsSpiAndArea()
+    {
+        var result = CadastralService.ParseArcGisParcelResponse(
+            VicSampleResponse, "VIC", parcelIdField: "parcel_spi", fallbackIdField: "parcel_plan_number", areaField: "Shape__Area");
+
+        Assert.NotNull(result);
+        Assert.Equal("VIC", result!.State);
+        Assert.Equal("PC366537", result.ParcelId);
+        Assert.Equal(6193.015625, result.AreaSquareMetres);
+    }
+
+    [Fact]
+    public void ParseArcGisParcelResponse_WithNoFeatures_ReturnsNull()
+    {
+        var result = CadastralService.ParseArcGisParcelResponse(
+            EmptyFeatureCollectionResponse, "NSW", "lotidstring", "planlabel", "shape_Area");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseArcGisParcelResponse_WhenPrimaryIdFieldMissing_FallsBackToSecondField()
+    {
+        var responseWithNullPrimaryId = """
+            {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[]},"properties":{"lotidstring":null,"planlabel":"DP999999","shape_Area":100.0}}]}
+            """;
+
+        var result = CadastralService.ParseArcGisParcelResponse(
+            responseWithNullPrimaryId, "NSW", "lotidstring", "planlabel", "shape_Area");
+
+        Assert.NotNull(result);
+        Assert.Equal("DP999999", result!.ParcelId);
+    }
+
+    // --- End-to-end through GetParcelByCoordinateAsync (state detection + HTTP + parsing) ---
+
+    [Fact]
+    public async Task GetParcelByCoordinateAsync_ForSydneyCoordinates_QueriesNswAndReturnsParsedParcel()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK, NswSampleResponse);
+        var options = new CadastralOptions
+        {
+            NSW = new StateConfig { Endpoint = "https://example.test/nsw-cadastre", Enabled = true }
+        };
+        var service = CreateService(handler, options);
+
+        // Sydney Opera House area - the coordinate named in issue #182's test plan.
+        var result = await service.GetParcelByCoordinateAsync(-33.8688, 151.2093, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("NSW", result!.State);
+        Assert.Equal("1//DP598704", result.ParcelId);
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Contains("geometryType=esriGeometryPoint", handler.LastRequestUri!.Query);
+        Assert.Contains("f=geojson", handler.LastRequestUri.Query);
+        Assert.Contains("151.2093", handler.LastRequestUri.Query);
+    }
+
+    [Fact]
+    public async Task GetParcelByCoordinateAsync_ForMelbourneCoordinates_QueriesVicAndReturnsParsedParcel()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK, VicSampleResponse);
+        var options = new CadastralOptions
+        {
+            VIC = new StateConfig { Endpoint = "https://example.test/vic-cadastre", Enabled = true }
+        };
+        var service = CreateService(handler, options);
+
+        // Melbourne CBD - the coordinate named in issue #182's test plan.
+        var result = await service.GetParcelByCoordinateAsync(-37.8136, 144.9631, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("VIC", result!.State);
+        Assert.Equal("PC366537", result.ParcelId);
+    }
+
+    [Fact]
+    public async Task GetParcelByCoordinateAsync_WhenStateDisabled_ReturnsNullWithoutCallingApi()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK, NswSampleResponse);
+        var options = new CadastralOptions
+        {
+            NSW = new StateConfig { Endpoint = "https://example.test/nsw-cadastre", Enabled = false }
+        };
+        var service = CreateService(handler, options);
+
+        var result = await service.GetParcelByCoordinateAsync(-33.8688, 151.2093, CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Null(handler.LastRequestUri);
+    }
+
+    [Fact]
+    public async Task GetParcelByCoordinateAsync_WhenApiReturnsError_ReturnsNull()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.InternalServerError, "");
+        var options = new CadastralOptions
+        {
+            NSW = new StateConfig { Endpoint = "https://example.test/nsw-cadastre", Enabled = true }
+        };
+        var service = CreateService(handler, options);
+
+        var result = await service.GetParcelByCoordinateAsync(-33.8688, 151.2093, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetParcelByCoordinateAsync_ForStateWithoutRealImplementation_ReturnsNull()
+    {
+        // QLD is configured with an endpoint but has no real implementation yet -
+        // must fail closed (null), not throw.
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK, NswSampleResponse);
+        var options = new CadastralOptions
+        {
+            QLD = new StateConfig { Endpoint = "https://example.test/qld-cadastre", Enabled = true }
+        };
+        var service = CreateService(handler, options);
+
+        // Brisbane CBD
+        var result = await service.GetParcelByCoordinateAsync(-27.4698, 153.0251, CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Null(handler.LastRequestUri);
+    }
+
+    // --- GetStateFromCoordinateAsync bounding-box detection ---
+
+    [Theory]
+    [InlineData(-33.8688, 151.2093, "NSW")] // Sydney
+    [InlineData(-37.8136, 144.9631, "VIC")] // Melbourne
+    [InlineData(-27.4698, 153.0251, "QLD")] // Brisbane
+    [InlineData(-35.2809, 149.1300, "ACT")] // Canberra
+    [InlineData(-42.8821, 147.3272, "TAS")] // Hobart
+    public async Task GetStateFromCoordinateAsync_ForKnownCityCoordinates_ReturnsExpectedState(
+        double lat, double lng, string expectedState)
+    {
+        var service = CreateService(new CapturingHttpMessageHandler(HttpStatusCode.OK, "{}"), new CadastralOptions());
+
+        var state = await service.GetStateFromCoordinateAsync(lat, lng, CancellationToken.None);
+
+        Assert.Equal(expectedState, state);
+    }
+
+    [Fact]
+    public async Task GetStateFromCoordinateAsync_OutsideAustralia_ReturnsNull()
+    {
+        var service = CreateService(new CapturingHttpMessageHandler(HttpStatusCode.OK, "{}"), new CadastralOptions());
+
+        // Auckland, New Zealand
+        var state = await service.GetStateFromCoordinateAsync(-36.8485, 174.7633, CancellationToken.None);
+
+        Assert.Null(state);
+    }
+
+    // --- Live smoke tests against the real government endpoints ---
+    // Skipped by default (external network dependency, not suitable for CI), but kept
+    // as an easy manual check that the real ArcGIS services still respond the way this
+    // implementation expects. Run manually by temporarily removing the Skip parameter below.
+
+    [Fact(Skip = "Hits a live external government API - run manually to verify against real data")]
+    public async Task Live_GetParcelByCoordinateAsync_ForSydneyOperaHouse_ReturnsNswParcel()
+    {
+        var service = new CadastralService(
+            new RealHttpClientFactory(),
+            new Logger<CadastralService>(new LoggerFactory()),
+            Options.Create(new CadastralOptions
+            {
+                NSW = new StateConfig
+                {
+                    Endpoint = "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Cadastre/MapServer/9",
+                    Enabled = true
+                }
+            }));
+
+        var result = await service.GetParcelByCoordinateAsync(-33.8688, 151.2093, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("NSW", result!.State);
+        Assert.False(string.IsNullOrEmpty(result.ParcelId));
+        Assert.True(result.AreaSquareMetres > 0);
+    }
+
+    [Fact(Skip = "Hits a live external government API - run manually to verify against real data")]
+    public async Task Live_GetParcelByCoordinateAsync_ForMelbourneCbd_ReturnsVicParcel()
+    {
+        var service = new CadastralService(
+            new RealHttpClientFactory(),
+            new Logger<CadastralService>(new LoggerFactory()),
+            Options.Create(new CadastralOptions
+            {
+                VIC = new StateConfig
+                {
+                    Endpoint = "https://services-ap1.arcgis.com/P744lA0wf4LlBZ84/ArcGIS/rest/services/Vicmap_Parcel/FeatureServer/0",
+                    Enabled = true
+                }
+            }));
+
+        var result = await service.GetParcelByCoordinateAsync(-37.8136, 144.9631, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("VIC", result!.State);
+        Assert.False(string.IsNullOrEmpty(result.ParcelId));
+        Assert.True(result.AreaSquareMetres > 0);
+    }
+
+    private class RealHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}


### PR DESCRIPTION
## Summary
`CadastralService.GetParcelFromStateApiAsync` was a full stub — it logged what it would do and always returned `null`, for every state. This implements the two highest-priority states (NSW, VIC) called out in #182, the actionable child issue of the #174 Azure Maps SDK v3 + cadastral epic (whose other sub-tasks — SDK upgrade, azure-maps.js, service/endpoint scaffolding, DI wiring, boundary toggle UI — are already merged).

**Research done before writing code** (both endpoints verified live against the exact coordinates named in #182's test plan):
- **NSW**: `NSW_Cadastre` MapServer, layer 9 ("Lot") — `https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_Cadastre/MapServer/9`. Was already correctly configured in `appsettings.json`.
- **VIC**: `Vicmap_Parcel` FeatureServer, layer 0 ("Parcel Map Polygons") — `https://services-ap1.arcgis.com/P744lA0wf4LlBZ84/ArcGIS/rest/services/Vicmap_Parcel/FeatureServer/0`. The existing config pointed at an unused WFS proxy URL for a different protocol; replaced with this verified ArcGIS REST endpoint.

Both services expose the same ArcGIS REST `query` operation shape (point geometry in, `f=geojson` out), so the query/parsing logic (`QueryArcGisParcelAsync` / `ParseArcGisParcelResponse`) is shared — only the parcel-ID and area field names differ per state's schema (`lotidstring`/`shape_Area` for NSW, `parcel_spi`/`Shape__Area` for VIC). `GetNswParcelAsync`/`GetVicParcelAsync` remain as named entry points per the issue's suggested method names.

**Testability:** `ParseArcGisParcelResponse` is `internal` (`InternalsVisibleTo` added to `fencemark.ApiService.csproj`) so the response-parsing logic can be unit tested directly against real captured JSON, without needing a live HTTP call for every test run.

## Test plan
- [x] `CadastralServiceTests` (15 tests): parsing against real captured NSW/VIC responses (exact field extraction, area values), empty-features handling, ID fallback-field logic, full `GetParcelByCoordinateAsync` through a faked `HttpMessageHandler` (verifies query string shape, state routing, disabled-state short-circuit, non-2xx handling), and `GetStateFromCoordinateAsync` bounding-box detection for 5 state capitals + outside-Australia
- [x] **2 live smoke tests** (`Live_GetParcelByCoordinateAsync_For{Sydney,Melbourne}...`) hit the real NSW/VIC government APIs end-to-end through the actual `CadastralService` — these are `[Fact(Skip = ...)]`'d for CI (external network dependency), but I ran them manually before committing and both passed against live data (real `ParcelId`s and areas returned) — this is what confirmed the endpoints/field names are correct, not just what the response *should* look like
- [x] `dotnet build` succeeds for `fencemark.ApiService` and `fencemark.Client`
- [x] `dotnet test fencemark.Tests --filter-not-namespace "fencemark.Tests.E2E"` — 150 passed, 13 skipped (11 Docker/Aspire-only + 2 live-API smoke tests), 0 failed

## Remaining scope in #174
This closes the NSW/VIC piece (#182). Still open per #174's acceptance criteria: QLD, TAS, ACT (Phase 1 "free states" not yet covered), NT (needs FTP-sync/caching strategy), SA/WA (paid, correctly disabled already), and DB-level caching of fetched boundaries for performance. Happy to continue with QLD/TAS/ACT next if wanted — each needs the same endpoint-verification treatment as NSW/VIC did here.

Fixes #182
Progresses #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)